### PR TITLE
Housekeeping: ignore temp files and log C1 completion

### DIFF
--- a/.!30410!alphabet.html
+++ b/.!30410!alphabet.html
@@ -1,4 +1,0 @@
-<!DOCTYPE HTML PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN" "http://www.w3c.org/TR/1999/REC-html401-19991224/loose.dtd">
-<!-- saved from url=(0037)http://www.syncat.com.ua/aphabet.html -->
-<HTML xmlns="http://www.w3.org/1999/xhtml">
-<!-- Mirrored from nlping.ru/alphabet.html by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 14:10:55 GMT -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 baseline_snapshot.tar*
 
+# ignore accidental temp files like .!12345!*.html
+.!*
+
 # Generated baseline artifacts (kept out of git to avoid huge diffs)
 baseline_md5.txt
 snapshot/*

--- a/DOROZHNAYA_KARTA.md
+++ b/DOROZHNAYA_KARTA.md
@@ -190,6 +190,7 @@ Cloudflare Pages отдаёт статический бэкап сайта `nlpi
 | 2025-09-28T16:44:44Z | C1 — перенёс блок «Видео» (video/index8d4e/print8d4e) | `python tools/check_links.py --scope video.html --scope index8d4e.html --scope print8d4e.html` → `logs/check_links-20250928T164430Z.json`; `python tools/check_utf8.py --scope video.html --scope index8d4e.html --scope print8d4e.html` → `logs/check_utf8-20250928T164433Z.json`; `python -m http.server` + `curl -I` по `video.html`, `index8d4e.html`, `print8d4e.html` | ✅ Раздел «Видео» работает из корня, продолжаю перенос оставшихся страниц. |
 | 2025-09-28T17:17:45Z | C1 — поднял ассеты раздела «Видео» (css/, js/, images/, img/, favicon.ico) в корень | `python tools/check_links.py --scope video.html --scope index8d4e.html --scope print8d4e.html` → `logs/check_links-20250928T171738Z.json`; `python tools/check_utf8.py --scope video.html --scope index8d4e.html --scope print8d4e.html` → `logs/check_utf8-20250928T171743Z.json` | ✅ Стили, скрипты и изображения раздела доступны из корня, ссылка на hop-интеграцию удалена. |
 | 2025-09-28T17:26:14Z | C1 — перенёс оставшиеся 2127 HTML верхнего уровня из `nlping.ru/` в корень | `python tools/check_links.py --scope .` → `logs/check_links-20250928T172536Z.json`; `python tools/check_utf8.py --scope . --no-manifest` → `logs/check_utf8-20250928T172548Z.json`; `python -m http.server 8000` + `curl -I` по `index.html`, `F48A6.html`, `setup925a.html` | ✅ Каталог `nlping.ru/` очищен от корневых HTML, страницы обслуживаются из нового положения. |
+| 2025-09-28T19:10:12Z | C1 — фиксация завершения: корневые HTML и раздел «Видео» работают из корня, наследие hop-трекера удалено | Проверки: `rg -n "my_hop_host" -g'*.html'` → пусто; `rg -n "s\\.nlping\\.ru/sapi/Click\\.js" -g'*.html'` → пусто; `git status -sb` | ✅ Шаг C1 закрыт, следующий этап — перенос ассетов (C2). |
 
 ## Текущее состояние дорожной карты
 
@@ -204,11 +205,7 @@ Cloudflare Pages отдаёт статический бэкап сайта `nlpi
 - ✅ C1: перенос корневых HTML завершён — весь верхний уровень переехал в корень, каталог `nlping.ru/` больше не содержит HTML-файлов.
 - ⏳ Остальные шаги (C2–E4) не начаты.
 
-Следующий шаг: C2 — переносить каталоги с ассетами из `nlping.ru/` партиями.
-
-Следующий шаг: C2 — переносить каталоги с ассетами из `nlping.ru/` партиями.
-
-**Следующий шаг:** довести до merge актуальный PR (**ветка задачи → `main`**) и затем перейти к **C2** — переносу каталогов с ассетами.
+**Следующий шаг:** C2 — переносить каталоги ассетов из `nlping.ru/` партиями (последовательно обновляя PR work → main).
 
 ### Быстрый старт сессии
 


### PR DESCRIPTION
## Summary
- ignore accidental `.!*` temp files via .gitignore and remove the previously tracked artifact
- update the migration roadmap to record C1 completion and point to C2 as the next focus

## Testing
- `rg -n "my_hop_host" -g'*.html'`
- `rg -n "s\\.nlping\\.ru/sapi/Click\\.js" -g'*.html'`


------
https://chatgpt.com/codex/tasks/task_e_68d987afbbd88327bfec0ef16f00f3de