### PR TITLE
feat: reencode F4A11-F4A46 GUID pages to UTF-8

### DIFF
--- a/DOROZHNAYA_KARTA.md
+++ b/DOROZHNAYA_KARTA.md
@@ -295,6 +295,8 @@ Cloudflare Pages отдаёт статический бэкап сайта `nlpi
 | 2025-10-03T19:41:52Z | D2 — перекодировал финальный блок `F48AB.html`…`F48ED.html` (10 файлов) | `python tools/reencode.py --paths F48AB.html … F48ED.html --limit 200` → `logs/reencode-20251003T194152Z.json`; `rg -n "windows-1251" F48*.html` → пусто | ✅ Подсерия `F48x` полностью в UTF-8, мета-теги обновлены. |
 | 2025-10-03T19:42:16Z | D2 — подтвердил кодировку и заголовки финального блока `F48x` | `python tools/check_utf8.py --no-manifest$(printf ' --scope %s' F48AB.html … F48ED.html)` → `logs/check_utf8-20251003T194210Z.json`; `python -m http.server 8000` + `curl -I` по `F48AB.html`, `F48E0.html`, `F48ED.html` | ✅ Проверки прошли, готов к подсерии `F49x`. |
 | 2025-10-03T19:52:13Z | D2 — перекодировал подсерии `F4902.html` и `F49ED.html`, подтвердил UTF-8 | `python tools/reencode.py --paths F4902.html F49ED.html` → `logs/reencode-20251003T195158Z.json`; `python - <<'PY'` (замена `charset=windows-1251` → `charset=utf-8`); `rg -n "windows-1251" F4902.html F49ED.html`; `python tools/check_utf8.py --no-manifest --scope F4902.html --scope F49ED.html` → `logs/check_utf8-20251003T195207Z.json`; `python -m http.server 8000` + `curl -I` по `F4902.html`, `F49ED.html` | ✅ Подсерия `F49x` подтверждена, следующая партия — `F4Ax`. |
+| 2025-10-03T20:03:47Z | D2 — перекодировал блок `F4A11.html`…`F4A46.html` (12 файлов) | `python tools/reencode.py --paths F4A11.html … F4A46.html` → `logs/reencode-20251003T200347Z.json`; `python - <<'PY'` (замена `charset=windows-1251` → `charset=utf-8` в партии); `rg -n "windows-1251" F4A11.html … F4A46.html` | ✅ Партия переведена в UTF-8, `safe_bound_html_guid` подтверждён. |
+| 2025-10-03T20:04:22Z | D2 — подтвердил кодировку блока `F4A11.html`…`F4A46.html` | `python tools/check_utf8.py --no-manifest$(printf ' --scope %s' F4A11.html … F4A46.html)` → `logs/check_utf8-20251003T200422Z.json`; ручной просмотр `F4A11.html`, `F4A29.html`, `F4A46.html` | ✅ Проверки прошли, следующая партия — `F4A47.html`…`F4A99.html`. |
 | 2025-09-28T19:10:12Z | C1 — фиксация завершения: корневые HTML и раздел «Видео» работают из корня, наследие hop-трекера удалено | Проверки: `rg -n "my_hop_host" -g'*.html'` → пусто; `rg -n "s\\.nlping\\.ru/sapi/Click\\.js" -g'*.html'` → пусто; `git status -sb` | ✅ Шаг C1 закрыт, следующий этап — перенос ассетов (C2). |
 
 #### Архив: чек-лист шага C1 (перенос корневых HTML)
@@ -324,9 +326,9 @@ Cloudflare Pages отдаёт статический бэкап сайта `nlpi
 - ✅ C3: HTTrack-артефакты удалены, README отражает новую структуру.
 - ✅ D0: `tools/reencode.py` перекодирует HTML/XML в UTF-8, тесты покрывают сценарии успеха/ошибок.
 - ✅ D1: корневые HTML, RSS и ключевые лендинги перекодированы в UTF-8 (`logs/reencode-20250930T070225Z.json`, `logs/check_utf8-20250930T070433Z.json`).
-- ▶️ D2: серии `index0*`/`print0*`, `index1*`/`print1*`, `index2*`/`print2*`, `index3*`/`print3*`, `index4*`/`print4*`, `index5*`/`print5*`, `index6*`/`print6*`, `index7*`/`print7*`, `index8*`/`print8*`, `index9*`/`print9*`, `indexa*`/`printa*`, `indexb*`/`printb*`, `indexc*`/`printc*`, `indexd*`/`printd*`, `indexe*`/`printe*`, `indexf*`/`printf*` и GUID-файлы `0*`–`F49*` перекодированы, впереди оставшиеся GUID-файлы `F*`.
+- ▶️ D2: серии `index0*`/`print0*`, `index1*`/`print1*`, `index2*`/`print2*`, `index3*`/`print3*`, `index4*`/`print4*`, `index5*`/`print5*`, `index6*`/`print6*`, `index7*`/`print7*`, `index8*`/`print8*`, `index9*`/`print9*`, `indexa*`/`printa*`, `indexb*`/`printb*`, `indexc*`/`printc*`, `indexd*`/`printd*`, `indexe*`/`printe*`, `indexf*`/`printf*` и GUID-файлы `0*`–`F4A46` перекодированы, впереди оставшиеся GUID-файлы `F*`.
 
-**Следующий шаг:** D2 — перекодировать GUID-файлы подсерии `F4Ax` (далее — `F4Cx`, `F4Dx`…).
+**Следующий шаг:** D2 — перекодировать следующую подсерию `F4A47.html`…`F4A99.html`, затем перейти к `F4AA1.html`…
 
 #### План партии `F*` (активен)
 
@@ -337,6 +339,7 @@ Cloudflare Pages отдаёт статический бэкап сайта `nlpi
 - **Блок 3a (✅ выполнено):** `F4833.html`…`F486E.html` — 12 файлов, подтверждён безопасный объём; логи `logs/reencode-20251003T122902Z.json`, `logs/check_utf8-20251003T122949Z.json`.
 - **Блок 3b (✅ выполнено):** `F4876.html`…`F48ED.html` — финальная подсерия перекодирована и проверена (`logs/reencode-20251003T194152Z.json`, `logs/check_utf8-20251003T194210Z.json`).
 - **Блок 4 (✅ выполнено):** `F4902.html`…`F49ED.html` — подтверждён перевод в UTF-8 (`logs/reencode-20251003T195158Z.json`, `logs/check_utf8-20251003T195207Z.json`).
+- **Блок 5 (✅ выполнено):** `F4A11.html`…`F4A46.html` — партия на 12 файлов, логи `logs/reencode-20251003T200347Z.json`, `logs/check_utf8-20251003T200422Z.json`.
 - После каждого блока обновляем таблицу прогресса и журнал лимитов.
 
 ### Быстрый старт сессии

--- a/F4A11.html
+++ b/F4A11.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A11 by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:13:21 GMT -->
 <head>
-        <title>Ïÿòü íàâûêîâ, âåäóùèõ ê äåíüãàì</title>
+        <title>Пять навыков, ведущих к деньгам</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="Íàâåðíÿêà Âû ÷àñòî ñëûøàëè òàêóþ ôðàçó: «Åñëè òû òàêîé óìíûé, òî ïî÷åìó òû òàêîé áåäíûé?» IQ è ýðóäèöèÿ íå ãàðàíòèðóþò Âàì îáåñïå÷åííóþ æèçíü. Ýìîöèîíàëüíûé èíòåëëåêò, êñòàòè, òîæå. Íóæíî êîå-÷òî åùå... " />
+        <meta name="description" content="Наверняка Вы часто слышали такую фразу: «Если ты такой умный, то почему ты такой бедный?» IQ и эрудиция не гарантируют Вам обеспеченную жизнь. Эмоциональный интеллект, кстати, тоже. Нужно кое-что еще... " />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='F48A6.html'>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</a> </span> / Ïÿòü íàâûêîâ, âåäóùèõ ê äåíüãàì                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='F48A6.html'>Бизнес, маркетинг и продажи</a> </span> / Пять навыков, ведущих к деньгам                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,116 +399,116 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print9bf4.html?id=F4A11"><img src="images/printer.jpg"></a></div>
-                                    <h1>Ïÿòü íàâûêîâ, âåäóùèõ ê äåíüãàì</h1>
+                                    <h1>Пять навыков, ведущих к деньгам</h1>
                                                                     <p>
                                         <p>
-	Íàâåðíÿêà Âû ÷àñòî ñëûøàëè òàêóþ ôðàçó: &laquo;Åñëè òû òàêîé óìíûé, òî ïî÷åìó òû òàêîé áåäíûé?&raquo; (Íå îáÿçàòåëüíî â ñâîé àäðåñ ;))</p>
+	Наверняка Вы часто слышали такую фразу: &laquo;Если ты такой умный, то почему ты такой бедный?&raquo; (Не обязательно в свой адрес ;))</p>
 <h2>
-	Êàê èçìåðèòü IQ â äåíüãàõ?</h2>
+	Как измерить IQ в деньгах?</h2>
 <p>
-	Æåñòîêàÿ ïðàâäà æèçíè çàêëþ÷àåòñÿ â òîì, ÷òî ðàçâèòûé èíòåëëåêò è ýðóäèöèÿ íå ãàðàíòèðóþò Âàì îáåñïå÷åííóþ æèçíü. Äàæå åñëè Âû áóäåòå ÷òî-òî àêòèâíî äåëàòü.<br />
+	Жестокая правда жизни заключается в том, что развитый интеллект и эрудиция не гарантируют Вам обеспеченную жизнь. Даже если Вы будете что-то активно делать.<br />
 	<br />
-	Ñêîëüêî ìû çíàåì ãåíèàëüíåéøèõ ó÷åíûõ, æèâóùèõ íà ïîðîãå áåäíîñòè?<br />
-	È ñêîëüêî âñåõ îñòàëüíûõ ó÷åíûõ âûíóæäåííûõ ïîäðàáàòûâàò ÷åì-òî äðóãèì?<br />
+	Сколько мы знаем гениальнейших ученых, живущих на пороге бедности?<br />
+	И сколько всех остальных ученых вынужденных подрабатыват чем-то другим?<br />
 	<br />
-	Íåêîòîðûå íàèâíî ïîëàãàþò, ÷òî âñå äåëî â äîêòîðñêîé ñòåïåíè, óæå îíà-òî òî÷íî îòêðîåò èì äâåðè â æèçíü! È òðàòÿò åùå íåñêîëüêî áåñöåííûõ ëåò...<br />
+	Некоторые наивно полагают, что все дело в докторской степени, уже она-то точно откроет им двери в жизнь! И тратят еще несколько бесценных лет...<br />
 	<br />
-	Åñëè ýòî ôàí èëè ñàìîðåàëèçàöèÿ, òî ýòî çäîðîâî. Åñëè ýòî äåéñòâèòåëüíî òàê.<br />
+	Если это фан или самореализация, то это здорово. Если это действительно так.<br />
 	<br />
-	Íî, êàê íè ïå÷àëüíî, â áîëüøèíñòâå ñëó÷àåâ âñå ÷òî äàåò ñòåïåíü - ýòî ñòàòóñ â ñâîåì êðóãå. È, ìîæåò áûòü, ÷óòü áîëüøå äåíåã, ÷åì áûëî. À âåäü õî÷åòñÿ, ÷òîáû ñåìüÿ æèëà ëó÷øå, ÷òîáû äåòè ó÷èëèñü â ïðåñòèæíûõ ÂÓÇàõ...<br />
+	Но, как ни печально, в большинстве случаев все что дает степень - это статус в своем круге. И, может быть, чуть больше денег, чем было. А ведь хочется, чтобы семья жила лучше, чтобы дети учились в престижных ВУЗах...<br />
 	<br />
-	ß íå õî÷ó ñêàçàòü, ÷òî çíàíèÿ - ýòî ïëîõî è ó÷èòñÿ áåññìûñëåííî. Íàîáîðîò! Íî ìåíÿ ïðîñòî âûìîðàæèâàåò ãëóïîñòü, êîòîðóþ òâîðÿò óìíûå ëþäè.<br />
+	Я не хочу сказать, что знания - это плохо и учится бессмысленно. Наоборот! Но меня просто вымораживает глупость, которую творят умные люди.<br />
 	<br />
-	Ãîðüêî ñìîòðåòü íà ëþäåé, òåðÿþùèõ ãîäû, çàñòàâëÿÿ ñåáÿ ãðûçòü ãðàíèò íàóêè ðàäè ñòàòóñà è áóìàæêè. È åùå áîëåå æàëêî ñìîòðåòü íà ó÷åáíûå çàâåäåíèÿ, òîðãóþùèå äèïëîìàìè è ñåðòèôèêàòàìè, à íà äåëå îáó÷àþùèìè óñòàðåâøåé èíôîðìàöèè, âìåñòî êîíêðåòíûõ íàâûêîâ.<br />
+	Горько смотреть на людей, теряющих годы, заставляя себя грызть гранит науки ради статуса и бумажки. И еще более жалко смотреть на учебные заведения, торгующие дипломами и сертификатами, а на деле обучающими устаревшей информации, вместо конкретных навыков.<br />
 	<br />
-	Êàêîé ïðîöåíò âûïóñêíèêîâ ðàáîòàåò ïî ñïåöèàëüíîñòè? È ñêîëüêî ïîëó÷àþò òå, êòî âñå-òàêè ðàáîòàåò?<br />
+	Какой процент выпускников работает по специальности? И сколько получают те, кто все-таки работает?<br />
 	<br />
-	Çíàíèÿ ñåãîäíÿ, íàâåðíî, ñàìàÿ öåííàÿ âåùü. Íî äëÿ òîãî ÷òîáû èõ ìîíåòèçèðîâàòü, ñàìèõ ýòèõ çíàíèé íå äîñòàòî÷íî. Íóæíî åùå êîå-÷òî. Èíà÷å âñå ÷òî îñòàíåòñÿ - ýòî ãîðäèòñÿ ñâîèìè äèïëîìàìè è ñåðòèôèêàòàìè, ÷òîáû íå âûãëÿäåòü ïîëíûì ëóçåðîì, êîãäà âîçðàñò óæå íå ïðîêàòèò çà îïðàâäàíèå.<br />
+	Знания сегодня, наверно, самая ценная вещь. Но для того чтобы их монетизировать, самих этих знаний не достаточно. Нужно еще кое-что. Иначе все что останется - это гордится своими дипломами и сертификатами, чтобы не выглядеть полным лузером, когда возраст уже не прокатит за оправдание.<br />
 	<br />
-	(Íàäåþñü, ýòî íå ïðî Âàñ, íî Âû âèäåëè ïîäîáíîå è ïîíèìàåòå ìåíÿ ãëóáîêî.)</p>
+	(Надеюсь, это не про Вас, но Вы видели подобное и понимаете меня глубоко.)</p>
 <h2>
-	Ìîæåò áûòü ýìîöèîíàëüíûé èíòåëëåêò ñïàñåò ìèð?</h2>
+	Может быть эмоциональный интеллект спасет мир?</h2>
 <p>
-	Ëåò äâàäöàòü íàçàä àìåðèêàíöû ïðîâåëè èññëåäîâàíèÿ. È âûÿñíèëè, ÷òî ìåíåäæåðû, îáëàäàþùèå ýìîöèîíàëüíûì èíòåëëåêòîì (ñïîñîáíîñòüþ ðàçëè÷àòü òîíêèå ýìîöèè) áîëåå óñïåøíû â äåëàõ, ÷åì îñòàëüíûå. Ïîíÿòíî, îíè çíà÷èòåëüíî ýôôåêòèâíåå â êîììóíèêàöèè - ïðîäàæàõ, ïåðåãîâîðàõ, etc.<br />
+	Лет двадцать назад американцы провели исследования. И выяснили, что менеджеры, обладающие эмоциональным интеллектом (способностью различать тонкие эмоции) более успешны в делах, чем остальные. Понятно, они значительно эффективнее в коммуникации - продажах, переговорах, etc.<br />
 	<br />
-	Íî! &nbsp;<br />
+	Но! &nbsp;<br />
 	<br />
-	Îíè òàê æå êàê è âñå îñòàëüíûå ïðîäîëæàþò ìíîãî ðàáîòàòü è òàê æå íåóìåëî îáðàùàþòñÿ ñ çàðàáîòàííûì. Ýìîöèîíàëüíûé èòåëëåêò òîæå îêàçàëñÿ íå êëþ÷åâûì â âîïðîñàõ îáåñïå÷åííîñòè.</p>
+	Они так же как и все остальные продолжают много работать и так же неумело обращаются с заработанным. Эмоциональный ителлект тоже оказался не ключевым в вопросах обеспеченности.</p>
 <h2>
-	×òî òàêîå äåíåæíûé èíòåëëåêò?</h2>
+	Что такое денежный интеллект?</h2>
 <p>
-	Óäèâèòåëüíî, íî ôàêò. Íàèáîëåå îáåñïå÷åííûå ëþäè íå ÿâëÿþòñÿ áîëåå óìíûìè èëè ýìîöèîíàëüíî &laquo;ïðîêà÷åííûìè&raquo;, íåæåëè âñå îñòàëüíûå. Èíîãäà ñðåäè íèõ ìû âñòðå÷àåì âîîáùå íå óìíûõ è íå êîììóíèêàáåëüíûõ (ìÿãêî ãîâîðÿ ;).<br />
+	Удивительно, но факт. Наиболее обеспеченные люди не являются более умными или эмоционально &laquo;прокаченными&raquo;, нежели все остальные. Иногда среди них мы встречаем вообще не умных и не коммуникабельных (мягко говоря ;).<br />
 	<br />
-	Âïîðó ïîâåðèòü â çâåçäû, êàðìó, ñóäüáó è ïðî÷óþ ýçîòåðèêó&hellip; èëè ñêçàçàòü, ÷òî &quot;èì ïîâåçëî&quot; ;))))<br />
-	Åñëè áû ìû íå èìåëè ìíîæåñòâà ïðèìåðîâ &laquo;self-made men&raquo;, êîòîðûå âûøëè èç áåäíîòû è ñäåëàëè ñåáÿ ñàìè. ß ëè÷íî çíàþ ìíîãî òàêèõ ëþäåé (è íå âñå èç íèõ áëåùóò çíàíèÿìè èëè âûñîêîé êîììóíèêàáåëüíîñòüþ).<br />
+	Впору поверить в звезды, карму, судьбу и прочую эзотерику&hellip; или скзазать, что &quot;им повезло&quot; ;))))<br />
+	Если бы мы не имели множества примеров &laquo;self-made men&raquo;, которые вышли из бедноты и сделали себя сами. Я лично знаю много таких людей (и не все из них блещут знаниями или высокой коммуникабельностью).<br />
 	<br />
-	<strong>×òî æå îòëè÷àåò ýòèõ ñ÷àñòëèâ÷èêîâ?</strong><br />
+	<strong>Что же отличает этих счастливчиков?</strong><br />
 	<br />
-	Èíòåëëåêò, êàê ôóíêöèÿ - ýòî ñïîñîáíîñòü íàøåãî ðàçóìà ðàçëè÷àòü. Íî, íàäåþñü, Âû ñìîòðåëè ìîè ïîñëåäíèå êîðîòêèå âèäåî ïðî àêòèâèçàöèþ ìîçãà (<a href="indexda68.html?id=activization_brain">òóò</a>) è ïîìíèòå, ÷òî îäíîãî èíòåëëåêòà äëÿ ìûøëåíèÿ íåäîñòàòî÷íî.<br />
+	Интеллект, как функция - это способность нашего разума различать. Но, надеюсь, Вы смотрели мои последние короткие видео про активизацию мозга (<a href="indexda68.html?id=activization_brain">тут</a>) и помните, что одного интеллекта для мышления недостаточно.<br />
 	<br />
-	Ëþáîé èíòåëëåêò (ëîãè÷åñêèé, ýìîöèîíàëüíûé, äåíåæíûé) ìîæíî ðàçâèòü, åñëè Âû ïîíèìàåòå çà÷åì Âàì ýòî íóæíî.<br />
+	Любой интеллект (логический, эмоциональный, денежный) можно развить, если Вы понимаете зачем Вам это нужно.<br />
 	<br />
-	Êîãäà Âû ó÷èòåñü ïðàâèëüíî ðàñïîðÿæàòüñÿ äåíüãàìè (íå òîëüêî òðàòèòü, íî è âêëàäûâàòü â ñåáÿ, â çíàíèÿ, â òî, ÷òî ïîìîæåò ïðåóìíîæèòü Âàø ñ÷åò) - Âû ðàçâèâàåòå â ñåáå äåíåæíûé èíòåëëåêò.<br />
+	Когда Вы учитесь правильно распоряжаться деньгами (не только тратить, но и вкладывать в себя, в знания, в то, что поможет преумножить Ваш счет) - Вы развиваете в себе денежный интеллект.<br />
 	<br />
-	Äåíåæíûé èíòåëëåêò - ýòî ñïîñîáíîñòü ðàçëè÷àòü (áóêâàëüíî) &laquo;â ÷åì åñòü äåíüãè, à â ÷åì èõ íåò&raquo;. Íà áîëåå òîíêîì óðîâíå - ãäå ïîòåíöèàë äåíåã ðàñòåò, à ãäå ïàäàåò. Íî îá ýòîì äàëüøå. È êîãäà Âû ñòàâèòå ïåðåä ñîáîé öåëü - ðîñò äîõîäà, íàâûê äåíåæíîãî èíòåëëåêòà ïåðâîñòåïåíåí.<br />
+	Денежный интеллект - это способность различать (буквально) &laquo;в чем есть деньги, а в чем их нет&raquo;. На более тонком уровне - где потенциал денег растет, а где падает. Но об этом дальше. И когда Вы ставите перед собой цель - рост дохода, навык денежного интеллекта первостепенен.<br />
 	<br />
-	Ìíîãèå íå ïåðâûé ãîä â áèçíåñå, íî óïîðíî ïûòàþòñÿ çàðàáàòûâàòü, îòíîñÿñü ê ñâîåìó äåëó êàê ê õîááè èëè êàê ê áëàãîòâîðèòåëüíîñòè. Íåêîòîðûå - êàê ê ñàìîðåàëèçàöèè ;) Ýòî âñå î÷åíü õîðîøî â ïðèíöèïå, íî ñíà÷àëà âåäü íóæíî îáåñïå÷èòü ñåáå è ñâîåé ñåìüå âîçìîæíîñòü ýòèì êîìôîðòíî çàíèìàòüñÿ? Íå òàê ëè?<br />
+	Многие не первый год в бизнесе, но упорно пытаются зарабатывать, относясь к своему делу как к хобби или как к благотворительности. Некоторые - как к самореализации ;) Это все очень хорошо в принципе, но сначала ведь нужно обеспечить себе и своей семье возможность этим комфортно заниматься? Не так ли?<br />
 	<br />
-	Ê ñîæàëåíèþ, ó íàñ î÷åíü ìíîãî ïðåäïðèíèìàòåëåé íå ðàçâèâàþò â ñåáå äåíåæíûé èíòåëëåêò (è äàæå íå ñëûøàëè íè÷åãî îá ýòîì). È â ðåçóëüòàòå îíè ãîäàìè òàùóò ñâîé áèçíåñ, îæèäàÿ &quot;êîãäà æå îí âûñòðåëèò&quot;... È íå ïîíèìàÿ, ÷òî ëèáî ýòî âîîáùå íå òîò áèçíåñ, êîòîðûé êîãäà-ëèáî âûñòðåëèò, ëèáî òîò, íî îíè ïðîñòî íå íàä òåì â íåì ðàáîòàþò.<br />
+	К сожалению, у нас очень много предпринимателей не развивают в себе денежный интеллект (и даже не слышали ничего об этом). И в результате они годами тащут свой бизнес, ожидая &quot;когда же он выстрелит&quot;... И не понимая, что либо это вообще не тот бизнес, который когда-либо выстрелит, либо тот, но они просто не над тем в нем работают.<br />
 	<br />
-	×òîáû íå áûòü ãîëîñëîâíûì, âîò Âàì ñðàçó ìàíóàë:</p>
+	Чтобы не быть голословным, вот Вам сразу мануал:</p>
 <h2>
-	Ïÿòü íàâûêîâ äåíåæíîãî èíòåëëåêòà</h2>
+	Пять навыков денежного интеллекта</h2>
 <p>
-	<strong>1. Ñëîâî &laquo;íèùåòà&raquo; îáðàçîâàëîñü îò ôðàçû &laquo;íå ñ÷èòàòü&raquo;.&#8232;</strong><br />
-	Êàê òîëüêî Âû íà÷èíàåòå ñ÷èòàòü äåíüãè (íå òîëüêî ïîëó÷åííûå è ïîòðà÷åííûå, íî è òå, ÷òî Âû ìîæåòå ïîëó÷èòü â ïåðñïåêòèâå), Âû íà÷èíàåòå âèäåòü âîçìîæíîñòè. Ïðèìåíèòå ìàòåìàòèêó ê áóäóùåìó.<br />
+	<strong>1. Слово &laquo;нищета&raquo; образовалось от фразы &laquo;не считать&raquo;.&#8232;</strong><br />
+	Как только Вы начинаете считать деньги (не только полученные и потраченные, но и те, что Вы можете получить в перспективе), Вы начинаете видеть возможности. Примените математику к будущему.<br />
 	<br />
-	<strong>2. Äåíüãè - ýòî îñíîâíàÿ ýíåðãèÿ ñîöèóìà.&#8232;</strong><br />
-	&quot;Ïîòåíöèàëüíàÿ&quot;, êîãäà ìû ãîâîðèì î ðàçìåðå ñ÷åòà. Èëè &quot;êèíåòè÷åñêàÿ&quot;, êîãäà ìû ãîâîðèì î òåêóùèõ èíâåñòèöèÿõ èëè îáîðîòíûõ ñðåäñòâàõ.<br />
+	<strong>2. Деньги - это основная энергия социума.&#8232;</strong><br />
+	&quot;Потенциальная&quot;, когда мы говорим о размере счета. Или &quot;кинетическая&quot;, когда мы говорим о текущих инвестициях или оборотных средствах.<br />
 	<br />
-	Ïîíÿòíî, ÷òî ýòî, ñâîåãî ðîäà ìåòàôîðà. Íî êîãäà Âû íà÷èíàåòå ìûñëèòü â åå ðàìêàõ, Âû íà÷èíàåòå âèäåòü ïðîäàæè - êàê îáìåí, äåíüãè - êàê ïîòîêè ýíåðãèè, à ðûíêè - êàê ôèíàíñîâûå åìêîñòè. È òî, ÷òî Âàì íóæíî äåëàòü - ýòî óïðàâëÿòü ýòèìè ïîòîêàìè, ñîçäàâàÿ îáìåíû ñ íàèáîëüøèìè ôèíàíñîâûìè åìêîñòÿìè, êîòîðûå Âàì äîñòóïíû.<br />
+	Понятно, что это, своего рода метафора. Но когда Вы начинаете мыслить в ее рамках, Вы начинаете видеть продажи - как обмен, деньги - как потоки энергии, а рынки - как финансовые емкости. И то, что Вам нужно делать - это управлять этими потоками, создавая обмены с наибольшими финансовыми емкостями, которые Вам доступны.<br />
 	<br />
-	Åùå îäíà &quot;ôèøêà&quot; - ýòî óìåíèå âèäåòü ðàçíîñòü ïîòåíöèàëîâ â îáìåíàõ, êîòîðàÿ áóêâàëüíî âñàñûâàåò äåíüãè èç ðûíêà â Âàø áèçíåñ. Íî ýòî ïðîäâèíóòûé óðîâåíü, î íåì íå çäåñü.<br />
+	Еще одна &quot;фишка&quot; - это умение видеть разность потенциалов в обменах, которая буквально всасывает деньги из рынка в Ваш бизнес. Но это продвинутый уровень, о нем не здесь.<br />
 	<br />
-	<strong>3. Ôèíàíñîâûé &laquo;áóôåð&raquo;.</strong><br />
-	Íå âàæíî, ñêîëüêî Âû çàðàáàòûâàåòå (èëè Âàø áèçíåñ). Íî åñëè ó Âàñ åñòü ðåçåðâíûé êýø, êîòîðûé ìîæíî ìãíîâåííî ïóñòèòü â îáîðîò, Âàì òóò æå îòêðûâàåòñÿ ìàññà âîçìîæíîñòåé åãî ïðèóìíîæèòü. Âû àâòîìàòè÷åñêè íà÷èíàåòå âèäåòü áîëüøèå ïîòîêè äåíåæíîé ýíåðãèè è äîñòóïû ê áîëåå ãëóáîêèì ôèíàíñîâûì åìêîñòÿì. Òîëüêî âûáèðàé âî ÷òî èíâåñòèðîâàòü! À åñëè Âû íå çíàåòå, âî ÷òî èíâåñòèðîâàòü - èíâåñòèðóéòå â çíàíèÿ. Óçíàåòå.<br />
+	<strong>3. Финансовый &laquo;буфер&raquo;.</strong><br />
+	Не важно, сколько Вы зарабатываете (или Ваш бизнес). Но если у Вас есть резервный кэш, который можно мгновенно пустить в оборот, Вам тут же открывается масса возможностей его приумножить. Вы автоматически начинаете видеть большие потоки денежной энергии и доступы к более глубоким финансовым емкостям. Только выбирай во что инвестировать! А если Вы не знаете, во что инвестировать - инвестируйте в знания. Узнаете.<br />
 	<br />
-	<strong>4. Íå íóæíî ìíîãî ðàáîòàòü - íóæíî äóìàòü è ïëàòèòü çà ðàáîòó äðóãèì.</strong><br />
-	Åñëè Âû ïðîáüåòå èíòåðíåò íà ïðåäìåò ñòîèìîñòè ïðîèçâîäñòâà èëè óñëóã, Âû óâèäèòå, ÷òî åñòü îãðîìíîå êîëè÷åñòâî ëþäåé è êîìïàíèé, ãîòîâûõ ñäåëàòü ïî Âàøåìó çàêàçó âñå ÷òî óãîäíî. Ïðè÷åì, çà î÷åíü íåáîëüøèå äåíüãè. Çà÷åì íàäðûâàòü ñåáÿ è ñâîþ êîìïàíèþ? Äåëåãèðóéòå è àóòñîðñèòå âñå ÷òî ìîæíî. À åñëè ó Âàñ óæå åñòü êîìàíäà - ó÷èòå ýòîìó âàøèõ ñîòðóäíèêîâ, è âû áóäåòå ðàçâèâàòüñÿ â ðàçû áûñòðåå.<br />
+	<strong>4. Не нужно много работать - нужно думать и платить за работу другим.</strong><br />
+	Если Вы пробьете интернет на предмет стоимости производства или услуг, Вы увидите, что есть огромное количество людей и компаний, готовых сделать по Вашему заказу все что угодно. Причем, за очень небольшие деньги. Зачем надрывать себя и свою компанию? Делегируйте и аутсорсите все что можно. А если у Вас уже есть команда - учите этому ваших сотрудников, и вы будете развиваться в разы быстрее.<br />
 	<br />
-	<strong>5. Êòî ýòî êóïèò?</strong><br />
-	Åñëè Âû ñ÷èòàåòå ýòîò âîïðîñ ãëàâíûì (à âñå îñòàëüíûå íà ïîëíîì ñåðüåçå âîîáùå íå ñóùåñòâåííûìè), òî ïîçâîëüòå ÿ ïîæìó Âàì ðóêó. Âû îáëàäàåòå äåíåæíûì èíòåëëåêòîì. Ïðè óñëîâèè, êîíå÷íî, ÷òî Âû ñòàâèòå àêöåíò íà ïåðâîå ñëîâî, à íå íà ïîñëåäíåå ;)<br />
+	<strong>5. Кто это купит?</strong><br />
+	Если Вы считаете этот вопрос главным (а все остальные на полном серьезе вообще не существенными), то позвольте я пожму Вам руку. Вы обладаете денежным интеллектом. При условии, конечно, что Вы ставите акцент на первое слово, а не на последнее ;)<br />
 	<br />
-	&laquo;Íàéòè ïîòðåáíîñòü è óäîâëåòâîðèòå åå&raquo; - âîò ñàìàÿ ãëàâíàÿ çàäà÷à ëþáîãî áèçíåñà. (Âîïðîñ &laquo;Êóäà ëó÷øå èíâåñòèðîâàòü?&raquo; ïðîñòî çàïðåòèòå ñåáå çàäàâàòü, ïîêà íå ïðîêà÷àåòåñü â ïåðâîì. À êîãäà ïðîêà÷àåòåñü, òî âòîðîãî âîïðîñà ñòîÿòü íå áóäåò.)<br />
+	&laquo;Найти потребность и удовлетворите ее&raquo; - вот самая главная задача любого бизнеса. (Вопрос &laquo;Куда лучше инвестировать?&raquo; просто запретите себе задавать, пока не прокачаетесь в первом. А когда прокачаетесь, то второго вопроса стоять не будет.)<br />
 	<br />
-	Â ýòîì è åñòü ñìûñë âñåõ áèçíåñîâ - äàâàòü ëþäÿì òî, ÷åãî ó íèõ íåò (íå â öåëîì ÷åëîâå÷åñòâó - ýòî äëÿ ìîíñòðîâ, à òàì è òîãäà, ãäå ïîêà åùå). Åñëè Âû ìîæåòå íàéòè starving crowd (àíãë. æàæäóùóþ òîëïó), òî ó Âàñ åñòü íèøà ãàðàíòèðîâàííî óñïåøíîãî áèçíåñà.<br />
+	В этом и есть смысл всех бизнесов - давать людям то, чего у них нет (не в целом человечеству - это для монстров, а там и тогда, где пока еще). Если Вы можете найти starving crowd (англ. жаждущую толпу), то у Вас есть ниша гарантированно успешного бизнеса.<br />
 	<br />
-	Äà, ñ õîðîøèì ìàðêåòèíãîì ìîæíî ïðîäàòü ïî÷òè âñå ÷òî óãîäíî. Íî ñ õîðîøåé íèøåé Âû áóäåòå èìåòü ïðîäàæè äàæå ïðè ñàìîì ïëîõîì ìàðêåòèíãå. Â íåñêîëüêî ðàç ìåíüøå, êîíå÷íî, íî áóäåòå.<br />
+	Да, с хорошим маркетингом можно продать почти все что угодно. Но с хорошей нишей Вы будете иметь продажи даже при самом плохом маркетинге. В несколько раз меньше, конечно, но будете.<br />
 	<br />
-	È íàïîñëåäîê Âàì â ïîìîùü:</p>
+	И напоследок Вам в помощь:</p>
 <h2>
-	Èíñòðóìåíòû äëÿ Âàøåãî áèçíåñà</h2>
+	Инструменты для Вашего бизнеса</h2>
 <p>
-	Ïèñàòü çäåñü, <strong>êàê íàéòè íèøó</strong> ÿ íå áóäó. Äëÿ ýòîãî óæå åñòü áåñïëàòíàÿ ìåòîäè÷êà, êîòîðóþ Âû ìîæåòå <a href="indexf0a1.html?id=niching">ñêà÷àòü çäåñü</a>. Âñå ÷òî íóæíî ñäåëàòü - ýòî èíâåñòèðîâàòü 15 ìèíóò â òî, ÷òîáû îòâåòèòü íà âîïðîñû àíêåòû, è íà âûõîäå ïîëó÷èòü ñâîþ íèøó.<br />
+	Писать здесь, <strong>как найти нишу</strong> я не буду. Для этого уже есть бесплатная методичка, которую Вы можете <a href="indexf0a1.html?id=niching">скачать здесь</a>. Все что нужно сделать - это инвестировать 15 минут в то, чтобы ответить на вопросы анкеты, и на выходе получить свою нишу.<br />
 	<br />
-	<strong>Åñëè Âàø ìîçã óñòàë, &quot;çàëèï â ðóòèíå&quot; è íå ãåíåðèò èäåè ïîòîêîì</strong>, òî ïðèìåíèòå òåõíèêè èç DVD-òðåíèíãà &laquo;<a href="indexda68.html?id=activization_brain">Àêòèâèçàöèÿ ìîçãà è êðåàòèâíîñòü</a>&raquo;.<br />
+	<strong>Если Ваш мозг устал, &quot;залип в рутине&quot; и не генерит идеи потоком</strong>, то примените техники из DVD-тренинга &laquo;<a href="indexda68.html?id=activization_brain">Активизация мозга и креативность</a>&raquo;.<br />
 	<br />
-	<strong>×òîáû ñïëàíèðîâàòü ñòðàòåãèþ áûñòðîãî ðàçâèòèÿ áèçíåñà</strong> - âîñïîëüçóéòåñü òåõíèêîé &laquo;Ãàëñòóê äÿäè Ñýìà&raquo; èç DVD-òðåíèíãà &laquo;<a href="index2bb9.html?id=intuition_in_strategy">Èíòóèöèÿ â ñòðàòåãè÷åñêèõ ðåøåíèÿõ</a>&raquo;. Êñòàòè, îòëè÷íî ðàáîòàåò äàæå äëÿ çàêîðåíåëûõ ëîãèêîâ - ïðîñòî èäåòå ïî øàáëîíó.<br />
+	<strong>Чтобы спланировать стратегию быстрого развития бизнеса</strong> - воспользуйтесь техникой &laquo;Галстук дяди Сэма&raquo; из DVD-тренинга &laquo;<a href="index2bb9.html?id=intuition_in_strategy">Интуиция в стратегических решениях</a>&raquo;. Кстати, отлично работает даже для закоренелых логиков - просто идете по шаблону.<br />
 	<br />
-	<strong>Íå óâåðåíû, ÷òî õâàòèò ìîòèâàöèè äîéòè äî êîíöà?</strong> Ñìîòðèòå è âíåäðÿéòå òåõíèêè èç DVD-òðåíèíãà &laquo;<a href="index61d9.html?id=motivation-to-goal">Ìîòèâàöèÿ â äâèæåíèè ê öåëè</a>&raquo;.<br />
+	<strong>Не уверены, что хватит мотивации дойти до конца?</strong> Смотрите и внедряйте техники из DVD-тренинга &laquo;<a href="index61d9.html?id=motivation-to-goal">Мотивация в движении к цели</a>&raquo;.<br />
 	<br />
-	<strong>Âîïðîñ, êàê ýòî ýôôåêòèâíåå ïðîäàòü?</strong> DVD-òðåíèíã &laquo;<a href="index1c82.html?id=manipulation_and_sale">Ìàíèïóëÿöèè è ïðîäàæè</a>&raquo; (÷àñòü ïðî ïðîäàæè).<br />
+	<strong>Вопрос, как это эффективнее продать?</strong> DVD-тренинг &laquo;<a href="index1c82.html?id=manipulation_and_sale">Манипуляции и продажи</a>&raquo; (часть про продажи).<br />
 	<br />
-	Íó à åñëè Âû õîòèòå ïðîñòðîèòü âåñü ìàðêåòèíã öåëèêîì, íà÷èíàÿ ñ âûáîðà íèøè è çàêàí÷èâàÿ òùàòåëüíî ñïëàíèðîâàííîé êîìïàíèåé (ñ ìèíèìàëüíûìè ðåêëàìíûìè âëîæåíèÿìè èëè âîîáùå áåç íèõ) - ïðèõîäèòå íà òðåíèíã &laquo;<a href="index3f0c.html?id=money-IQ">Äåíåæíûé èíòåëëåêò</a>&raquo;.<br />
+	Ну а если Вы хотите простроить весь маркетинг целиком, начиная с выбора ниши и заканчивая тщательно спланированной компанией (с минимальными рекламными вложениями или вообще без них) - приходите на тренинг &laquo;<a href="index3f0c.html?id=money-IQ">Денежный интеллект</a>&raquo;.<br />
 	<br />
-	Òàì ìû &laquo;âñòðîèì&raquo; äåíåæíûé èíòåëëåêò â Âàøå ìûøëåíèå. À â õîäå ñàìîãî òðåíèíãà Âû ñîçäàäèòå áèçíåñ-ïëàí Âàøåãî ïðîåêòà è âñþ ìàðêåòèíãîâóþ ñòðàòåãèþ ïî íîâåéøèì òåõíîëîãèÿì ïðîäàæ.<br />
-	...À ïîòîì åùå ïîääåðæèì Âàñ êîó÷èíãîì â åæåíåäåëüíûõ çàíÿòèÿõ ìàñòåð-ãðóïïû.</p>
+	Там мы &laquo;встроим&raquo; денежный интеллект в Ваше мышление. А в ходе самого тренинга Вы создадите бизнес-план Вашего проекта и всю маркетинговую стратегию по новейшим технологиям продаж.<br />
+	...А потом еще поддержим Вас коучингом в еженедельных занятиях мастер-группы.</p>
 <h2>
-	Ëó÷øå ñåé÷àñ!</h2>
+	Лучше сейчас!</h2>
 <p>
-	Íàïîìèíàþ, ÷òî <strong>ñ 18 ïî 19 èþëÿ</strong> ó íàñ èäåò <a href="index9432.html?id=sale">ðàñïðîäàæà</a>, è âñå ïåðå÷èñëåííûå òðåíèíãè Âû ìîæåòå ïîëó÷èòü ñî ñêèäêîé 75% - òî åñòü, âñåãî <strong>çà ÷åòâåðòü öåíû</strong>. Íå òîðîïèòåñü, òùàòåëüíî ïîäóìàéòå ÷òî Âàì íóæíî - äî êîíöà <a href="index9432.html?id=sale">ðàñïðîäàæè</a> åùå öåëûé äåíü. À íàø ìåíåäæåð ïîìîæåò Âàì ðåøèòü âñå âîïðîñû ïî òåë: (495) 772-68-73.</p>
+	Напоминаю, что <strong>с 18 по 19 июля</strong> у нас идет <a href="index9432.html?id=sale">распродажа</a>, и все перечисленные тренинги Вы можете получить со скидкой 75% - то есть, всего <strong>за четверть цены</strong>. Не торопитесь, тщательно подумайте что Вам нужно - до конца <a href="index9432.html?id=sale">распродажи</a> еще целый день. А наш менеджер поможет Вам решить все вопросы по тел: (495) 772-68-73.</p>
 <p style="text-align: right;">
-	<em>Åãîð Áóëûãèí<br />
+	<em>Егор Булыгин<br />
 	18.07.2011</em></p>
 <p style="text-align: center;">
 	<a name='vote'></a><script type='text/javascript'>
@@ -533,16 +533,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setupd9fa.html?id=F4A11&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup3e63.html?id=F4A11&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup52c1.html?id=F4A11&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup85b5.html?id=F4A11&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupc105.html?id=F4A11&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupd9fa.html?id=F4A11&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup3e63.html?id=F4A11&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup52c1.html?id=F4A11&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup85b5.html?id=F4A11&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupc105.html?id=F4A11&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -565,7 +565,7 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div> <div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Áèçíåñ, ìàðêåòèíã è ïðîäàæè&quot;</p> <ul><li><a href='F4AF2.html' title='Óïðàæíåíèå, ïîçâîëÿþùåå îïðåäåëèòü âàøó íèøó, óâèäåòü âàøåãî êëèåíòà è ñïîñîáû åãî ïðèâëå÷åíèÿ'>Âàø Áîá</a></li><li><a href='F4A88.html' title='Êàê òîëüêî Âû íà÷èíàåòå çàíèìàòüñÿ áèçíåñîì èëè ïðîäàæàìè, Âû ïîïàäàåòå â êëàññè÷åñêóþ äèëåììó Ëèäåðà: «Áûòü õîðîøèì ÷åëîâåêîì èëè ýôôåêòèâíî óïðàâëÿòü?».  Êàê âûéòè èç ýòîé äèëåììû è ñîâìåñòèòü è òî, è òî?'>Õîðîøèé äðóã - ïëîõîé äèðåêòîð. Êàê ñîâìåñòèòü è òî, è òî?</a></li><li><a href='F48AF.html' title='Ïðî îäèí èç ãëàâíûõ íàâûêîâ áèçíåñ-ìûøëåíèÿ, êîòîðûé íå òîëüêî äåëàåò íàøè äåéñòâèÿ íà ïîðÿäîê ýôôåêòèâíåå, íî è âûâîäèò íà íîâûé óðîâåíü çðåëîñòè.'>Õîòèòå ëó÷øèõ ðåçóëüòàòîâ? Ìûñëèòå ïðîåêòàìè!</a></li><li><a href='F4CE5.html' title=''>Ñàìûå ïîêóïàåìûå òåìû 2012<br/> (ñòàòèñòèêà ðàñïðîäàæè)</a></li><li><a href='F4C29.html' title='Ìîæíî âîñïðèíÿòü ýòó ñòàòüþ êàê øóòêó, à ìîæíî è êîå-÷òî ïîëåçíîå äëÿ ñåáÿ óçàòü ;) Íàïèøèòå, ïîæàëóéñòà, â êîììåíòàðèÿõ íàèáîëåå èíòåðåñíûå âàì òåìû (êàêîé òðåíèíã âû êóïèëè áû), èëè ïðèäóìàéòå ñâîþ òåìó. Òàêæå, ïðî÷èòàéòå ÷óæèå êîììåíòàðèè, è åñëè âàøà òåìà ñîâïàäàåò ñ ÷üåé-òî, òî ïîñòàâüòå êîììåíòàðèþ Ëàéê.'>Òåìû òðåíèíãîâ, ìîçãîâîé øòóðì</a></li></ul></div> 
+<!-- AddThis Button END --></div> <div class='relateditems'><p>Лучшие материалы раздела &quot;Бизнес, маркетинг и продажи&quot;</p> <ul><li><a href='F4AF2.html' title='Упражнение, позволяющее определить вашу нишу, увидеть вашего клиента и способы его привлечения'>Ваш Боб</a></li><li><a href='F4A88.html' title='Как только Вы начинаете заниматься бизнесом или продажами, Вы попадаете в классическую дилемму Лидера: «Быть хорошим человеком или эффективно управлять?».  Как выйти из этой дилеммы и совместить и то, и то?'>Хороший друг - плохой директор. Как совместить и то, и то?</a></li><li><a href='F48AF.html' title='Про один из главных навыков бизнес-мышления, который не только делает наши действия на порядок эффективнее, но и выводит на новый уровень зрелости.'>Хотите лучших результатов? Мыслите проектами!</a></li><li><a href='F4CE5.html' title=''>Самые покупаемые темы 2012<br/> (статистика распродажи)</a></li><li><a href='F4C29.html' title='Можно воспринять эту статью как шутку, а можно и кое-что полезное для себя узать ;) Напишите, пожалуйста, в комментариях наиболее интересные вам темы (какой тренинг вы купили бы), или придумайте свою тему. Также, прочитайте чужие комментарии, и если ваша тема совпадает с чьей-то, то поставьте комментарию Лайк.'>Темы тренингов, мозговой штурм</a></li></ul></div> 
 <script>
 var idcomments_acct = '17aaea12c8826f1a4adde6fd2173ce48';
 var idcomments_post_id = 'F4A11';
@@ -591,11 +591,11 @@ var idcomments_post_url = 'F4A11.html';
 		  fjs.parentNode.insertBefore(js, fjs);
 		}(document, 'script', 'facebook-jssdk'));</script>
 
-<h3>Êîììåíòàðèè Facebook</h3>
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A11" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -616,12 +616,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -645,8 +645,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -654,11 +654,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -717,7 +717,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -739,7 +739,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A12.html
+++ b/F4A12.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A12 by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:16:55 GMT -->
 <head>
-        <title>Òâîÿ ÷àøà ñëèøêîì ïîëíà â÷åðàøíèì ÷àåì</title>
+        <title>Твоя чаша слишком полна вчерашним чаем</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="Â òåìó çàâåðøåíèÿ ðàñïðîäàæè ÿ õî÷ó ïîäåëèòüñÿ ñ Âàìè èçâåñòíîé ïðèò÷åé â òðåíåðñêîé ðàìêå..." />
+        <meta name="description" content="В тему завершения распродажи я хочу поделиться с Вами известной притчей в тренерской рамке..." />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='600117C7-F45F0-9F94D6EA.html'>Áàéêè è ïðèò÷è</a> </span> / Òâîÿ ÷àøà ñëèøêîì ïîëíà â÷åðàøíèì ÷àåì                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='600117C7-F45F0-9F94D6EA.html'>Байки и притчи</a> </span> / Твоя чаша слишком полна вчерашним чаем                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,75 +399,75 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print3836.html?id=F4A12"><img src="images/printer.jpg"></a></div>
-                                    <h1>Òâîÿ ÷àøà ñëèøêîì ïîëíà â÷åðàøíèì ÷àåì</h1>
+                                    <h1>Твоя чаша слишком полна вчерашним чаем</h1>
                                                                     <p>
                                         <p>
-	Ðàñïðîäàæà ÍËÏ-òðåíèíãîâ çàêîí÷èòñÿ ñåãîäíÿ â 23:59. Ýòî ïîñëåäíèé øàíñ ïîëó÷èòü æåëàåìûå òðåíèíãè çà ÷åòâåðòü öåíû, <a href="index9432.html?id=sale">âîñïîëüçóéòåñü èì</a>.<br />
+	Распродажа НЛП-тренингов закончится сегодня в 23:59. Это последний шанс получить желаемые тренинги за четверть цены, <a href="index9432.html?id=sale">воспользуйтесь им</a>.<br />
 	<br />
-	È â òåìó çàâåðøåíèÿ ðàñïðîäàæè ÿ õî÷ó ïîäåëèòüñÿ ñ Âàìè èçâåñòíîé ïðèò÷åé â òðåíåðñêîé ðàìêå:<br />
+	И в тему завершения распродажи я хочу поделиться с Вами известной притчей в тренерской рамке:<br />
 	<br />
-	Äëÿ íà÷èíàþùèõ - ôîêóñ âíèìàíèÿ íà ãåðîÿ ïðèò÷è è âîïðîñû â êîíöå.<br />
-	Äëÿ ïðîäâèíóòûõ - ôîêóñ íà âñåõ îñòàëüíûõ, íóæíûå âîïðîñû âíóòðè Âàñ.<br />
-	Äëÿ ÍËÏåðîâ - ÍËÏåðñêàÿ êîíöîâêà ;)</p>
+	Для начинающих - фокус внимания на героя притчи и вопросы в конце.<br />
+	Для продвинутых - фокус на всех остальных, нужные вопросы внутри Вас.<br />
+	Для НЛПеров - НЛПерская концовка ;)</p>
 <h3>
-	<em>Ìîæíî âåðèòü... à ìîæíî íå âåðèòü è ñëåäîâàòü</em></h3>
+	<em>Можно верить... а можно не верить и следовать</em></h3>
 <p>
-	<em>Îäèí ÷åëîâåê áûë î÷åíü óáåæäåííûì âåðóþùèì. È âñåì âñåãäà ãîâîðèë, íàñêîëüêî îí ñèëüíî âåðèò â Áîãà.<br />
-	È âîò îäíàæäû ñëó÷èëîñü íàâîäíåíèå è âîäà ïðèáûâàëà ñ îãðîìíîé ñêîðîñòüþ.<br />
+	<em>Один человек был очень убежденным верующим. И всем всегда говорил, насколько он сильно верит в Бога.<br />
+	И вот однажды случилось наводнение и вода прибывала с огромной скоростью.<br />
 	<br />
-	Â äîì ê ÷åëîâåêó ïðèøëè ëþäè è ñêàçàëè:<br />
+	В дом к человеку пришли люди и сказали:<br />
 	<br />
-	- Ãðÿäåò íàâîäíåíèå. Ìû ïîêèäàåì ýòî ìåñòî, ïîøëè ñ íàìè.<br />
+	- Грядет наводнение. Мы покидаем это место, пошли с нами.<br />
 	<br />
-	Íî îí îòâåòèë:<br />
+	Но он ответил:<br />
 	<br />
-	- Íåò, ÿ îñòàþñü. ß âåðóþ â Ãîñïîäà. Îí ñïàñ¸ò ìåíÿ.<br />
+	- Нет, я остаюсь. Я верую в Господа. Он спасёт меня.<br />
 	<br />
-	Ëþäè ïîæàëè ïëå÷àìè è óøëè.<br />
+	Люди пожали плечами и ушли.<br />
 	<br />
-	Âîäà ïðîäîëæàëà ïðèáûâàòü. Êîãäà äîì áûë íàïîëîâèíó çàòîïëåí, ê íåìó ïîäïëûëà ëîäêà. È ëþäè, ñèäÿùèå â íåé, ñêàçàëè:<br />
+	Вода продолжала прибывать. Когда дом был наполовину затоплен, к нему подплыла лодка. И люди, сидящие в ней, сказали:<br />
 	<br />
-	- Âîäà áóäåò ïðèáûâàòü è äàëüøå! Çäåñü åñòü åù¸ îäíî ìåñòî, ïîåõàëè ñ íàìè!<br />
+	- Вода будет прибывать и дальше! Здесь есть ещё одно место, поехали с нами!<br />
 	<br />
-	Íî ÷åëîâåê îòâåòèë:<br />
+	Но человек ответил:<br />
 	<br />
-	- Íåò. ß âåðóþ â Ãîñïîäà. Îí ñïàñåò ìåíÿ!<br />
+	- Нет. Я верую в Господа. Он спасет меня!<br />
 	<br />
-	Ëîäêà óïëûëà.<br />
+	Лодка уплыла.<br />
 	<br />
-	Êîãäà äîì áûë çàòîïëåí ïîëíîñòüþ, è ÷åëîâåê óæå ñèäåë íà ìàëåíüêîì ïÿòà÷êå êðûøè, ïðèëåòåë âåðòîë¸ò. Îòòóäà êðèêíóëè:<br />
+	Когда дом был затоплен полностью, и человек уже сидел на маленьком пятачке крыши, прилетел вертолёт. Оттуда крикнули:<br />
 	<br />
-	- Ýé, ýòî òâîé ïîñëåäíèé øàíñ. Ìû áðîñèì âåð¸âêó, ïî íåé òû ñìîæåøü çàáðàòüñÿ ñþäà. Áîëüøå ïîìîùè æäàòü íåîòêóäà.<br />
+	- Эй, это твой последний шанс. Мы бросим верёвку, по ней ты сможешь забраться сюда. Больше помощи ждать неоткуда.<br />
 	<br />
-	Íî ÷åëîâåê îòâåòèë:<br />
+	Но человек ответил:<br />
 	<br />
-	- Íåò. ß âåðóþ â Ãîñïîäà. Îí îáÿçàòåëüíî ñïàñåò ìåíÿ!<br />
+	- Нет. Я верую в Господа. Он обязательно спасет меня!<br />
 	<br />
-	Âåðòîëåò óëåòåë. Âîäà ïðîäîëæèëà ïðèáûâàòü, è âñêîðå ÷åëîâåê óòîíóë.<br />
+	Вертолет улетел. Вода продолжила прибывать, и вскоре человек утонул.<br />
 	<br />
-	Âñòðåòèâ íà íåáåñàõ Áîãà, ÷åëîâåê ñïðîñèë åãî:<br />
+	Встретив на небесах Бога, человек спросил его:<br />
 	<br />
-	- ß òàê âåðèë â òåáÿ, Ãîñïîäè, ïî÷åìó æå òû íå ñïàñ ìåíÿ?<br />
+	- Я так верил в тебя, Господи, почему же ты не спас меня?<br />
 	<br />
-	Íà ÷òî Áîã îòâåòèë:<br />
+	На что Бог ответил:<br />
 	<br />
-	- ß òðèæäû ïûòàëñÿ ñïàñòè òåáÿ, íî òû ïðîèãíîðèðîâàë äàæå âåðòîë¸ò!</em><br />
+	- Я трижды пытался спасти тебя, но ты проигнорировал даже вертолёт!</em><br />
 	<br />
-	<em><strong>ÍËÏåðñêàÿ êîíöîâêà</strong></em><br />
+	<em><strong>НЛПерская концовка</strong></em><br />
 	<br />
-	<em>- Ãîñïîäè, ïî÷åìó æå òû íå ñïàñ ìåíÿ? - âîçìóòèëñÿ ÍËÏåð. - ß æå áûë â òàêîì ðàïïîðòå ñ òîáîé!<br />
-	Áîã âçäîõíóë è îòâåòèë:<br />
-	- ß òóò îòêàëèáðîâàë òâîè ïàòòåðíû, è óâèäåë ÷òî </em><em>òâîÿ ÷àøà ñëèøêîì ïîëíà â÷åðàøíèì ÷àåì. Ò</em><em>åáå íóæíî óòîíóòü åùå 534 ðàçà, ïðåæäå ÷åì òû ïîéìåøü, ÷òî çíà÷èò áûòü â ðàïïîðòå ñî ìíîé.</em><br />
+	<em>- Господи, почему же ты не спас меня? - возмутился НЛПер. - Я же был в таком раппорте с тобой!<br />
+	Бог вздохнул и ответил:<br />
+	- Я тут откалибровал твои паттерны, и увидел что </em><em>твоя чаша слишком полна вчерашним чаем. Т</em><em>ебе нужно утонуть еще 534 раза, прежде чем ты поймешь, что значит быть в раппорте со мной.</em><br />
 	<br />
-	Î ÷åì ýòà ïðèò÷à?<br />
-	Î ñëåïîé óáåæäåííîñòè â ñâîèõ èäåÿõ?<br />
-	Îá óìåíèè âèäåòü äâèæåíèÿ Áîãà â "îáû÷íûõ" âåùàõ?<br />
-	Èëè îá îæèäàíèè ÷óäà, âìåñòî ëè÷íîé îòâåòñòâåííîñòè è äåéñòâèÿ?<br />
+	О чем эта притча?<br />
+	О слепой убежденности в своих идеях?<br />
+	Об умении видеть движения Бога в "обычных" вещах?<br />
+	Или об ожидании чуда, вместо личной ответственности и действия?<br />
 	<br />
-	<strong>P.S.</strong> Âåðòîëåò óëåòàåò ñåãîäíÿ â 23:59 ;)<br />
-	<strong>P.P.S. </strong>Âûïèñàííûé <a href="index9432.html?id=sale">â ðàñïðîäàæó</a> ñ÷åò äåéñòâèòåëåí äëÿ îïëàòû â òå÷åíèå 24 ÷àñîâ.</p>
+	<strong>P.S.</strong> Вертолет улетает сегодня в 23:59 ;)<br />
+	<strong>P.P.S. </strong>Выписанный <a href="index9432.html?id=sale">в распродажу</a> счет действителен для оплаты в течение 24 часов.</p>
 <p style="text-align: right;">
-	<em>Åãîð Áóëûãèí<br />
+	<em>Егор Булыгин<br />
 	19.07.2011</em></p>
                                     </p>
                                 </div>
@@ -484,12 +484,12 @@
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -513,8 +513,8 @@
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -522,11 +522,11 @@
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -585,7 +585,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -607,7 +607,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A18.html
+++ b/F4A18.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A18 by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:03:57 GMT -->
 <head>
-        <title>Äâà ïðàâèëà ëó÷øåãî òðåíèíãà</title>
+        <title>Два правила лучшего тренинга</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="×òî íóæíî ñäåëàòü íà÷èíàþùåìó òðåíåðó, ÷òîáû ñîçäàòü âîñòðåáîâàííûé òðåíèíã." />
-        <meta name="keywords" content="ëó÷øèå òðåíèíãè" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta name="description" content="Что нужно сделать начинающему тренеру, чтобы создать востребованный тренинг." />
+        <meta name="keywords" content="лучшие тренинги" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='11E0E292-F4297-CBD0453C.html'>Äëÿ ÍËÏåðîâ</a> </span> / Äâà ïðàâèëà ëó÷øåãî òðåíèíãà                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='11E0E292-F4297-CBD0453C.html'>Для НЛПеров</a> </span> / Два правила лучшего тренинга                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,120 +399,120 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print12ac.html?id=F4A18"><img src="images/printer.jpg"></a></div>
-                                    <h1>Äâà ïðàâèëà ëó÷øåãî òðåíèíãà</h1>
+                                    <h1>Два правила лучшего тренинга</h1>
                                                                     <p>
                                         <p>
-	Òðàäèöèîííî ñ÷èòàåòñÿ ÷òî íà ÍËÏ-òðåíèíãàõ ìíîãî íå çàðàáîòàåøü (åñëè èõ ïðîäàâàòü êàê ÍËÏ-òðåíèíãè, à íå ïåðåïîçèöèîíèðîâàòü â áèçíåñ). Íî íà ñàìîì äåëå ýòî íå òàê.<br />
+	Традиционно считается что на НЛП-тренингах много не заработаешь (если их продавать как НЛП-тренинги, а не перепозиционировать в бизнес). Но на самом деле это не так.<br />
 	<br />
-	Ìîæíî ïîçèöèîíèðîâàòü ñâîé òðåíèíã êàê ÍËÏ-òðåíèíã, è ëþäè áóäóò åãî îõîòíî ïîêóïàòü â íîðìàëüíîé öåíîâîé êàòåãîðèè (10.000ð. - 20.000 ð.). Ìîé îïûò - òîìó äîêàçàòåëüñòâî. Âîïðîñ â òîì - êàê ýòî ñäåëàòü. Îá ýòîì íèæå.</p>
+	Можно позиционировать свой тренинг как НЛП-тренинг, и люди будут его охотно покупать в нормальной ценовой категории (10.000р. - 20.000 р.). Мой опыт - тому доказательство. Вопрос в том - как это сделать. Об этом ниже.</p>
 <h2>
-	Ñíà÷àëà ïîâjobûâàé çà èìÿ è çà îïûò</h2>
+	Сначала повjobывай за имя и за опыт</h2>
 <p>
-	11 ëåò íàçàä ÿ ïîøåë ó÷èòüñÿ ÍËÏ, ÷òîáû íàó÷èòüñÿ ïî-íàñòîÿùåìó õîðîøî ïðîäàâòü ;)))) ...Íî, ê ñ÷àñòüþ, ÍËÏ äàëî ìíå íå÷òî áîëüøåå - ìîäåëèðîâàíèå. È ïðèâåëî ìåíÿ ê òîìó, ÷òî ìíå íðàâèòüñÿ äåëàòü áîëüøå âñåãî - ñîçäàíèþ è ïðîâåäåíèþ òðåíèíãîâ.<br />
+	11 лет назад я пошел учиться НЛП, чтобы научиться по-настоящему хорошо продавть ;)))) ...Но, к счастью, НЛП дало мне нечто большее - моделирование. И привело меня к тому, что мне нравиться делать больше всего - созданию и проведению тренингов.<br />
 	<br />
-	Îäíàêî, ïîëó÷èâ ñâîé òðåíåðñêèé ñåðòèôèêàò, ÿ îêàçàëñÿ êàê-òî íå óäåë. Ïðîôåññèÿ ïîÿâèëàñü, à ðàáîòàòü îêàçàëîñü íåãäå. ÍËÏ-öåíòðû ïðåäëàãàëè âåñòè ôàêóëüòàòèâû çà ïîëòîðû òûñÿ÷è ðóáëåé. È, åñëè íàáüþñü ê êîìó-òî â ïàðó, ìîæåò áûòü äàæå ïðîâåñòè ñòóïåíüêó ïðàêòèêà. Åùå òûñÿ÷ ïÿòü ðàç â ïàðó ìåñÿöåâ.<br />
+	Однако, получив свой тренерский сертификат, я оказался как-то не удел. Профессия появилась, а работать оказалось негде. НЛП-центры предлагали вести факультативы за полторы тысячи рублей. И, если набьюсь к кому-то в пару, может быть даже провести ступеньку практика. Еще тысяч пять раз в пару месяцев.<br />
 	<br />
-	Íå çíàþ, ìîæåò ñåé÷àñ ñèòóàöèÿ èçìåíèëàñü. Íî òîãäà, êàê ÿ ïîìíþ, ïî÷òè âñå ñâåæåâûïóùåííûå òðåíåðû áûëè â ýòîé ñèòóàöèè (êðîìå òåõ, êòî óæå ñàì ïðîäàâàë ñâîè òðåíèíãè).</p>
+	Не знаю, может сейчас ситуация изменилась. Но тогда, как я помню, почти все свежевыпущенные тренеры были в этой ситуации (кроме тех, кто уже сам продавал свои тренинги).</p>
 <p>
-	Ïîëó÷àëîñü, ÷òî ëèáî òû âjobûâàåøü çà èìÿ è çà îïûò. È íàäååøüñÿ, ÷òî ÷åðåç ãîä-äâà &laquo;êîãäà òû ðàñêðóòèøüñÿ&raquo;, òåáÿ âûïóñòÿò íà áîëüøóþ àðåíó è ìîæåò áûòü ñòàíóò ïëàòèòü áîëüøå.</p>
+	Получалось, что либо ты вjobываешь за имя и за опыт. И надеешься, что через год-два &laquo;когда ты раскрутишься&raquo;, тебя выпустят на большую арену и может быть станут платить больше.</p>
 <p>
-	Ëèáî òû èäåøü è ïðîäàåøü ñâîè òðåíèíãè ñàì.</p>
+	Либо ты идешь и продаешь свои тренинги сам.</p>
 <h2>
-	Ñàìûé ñòðàííûé ïàðàäîêñ ÍËÏ</h2>
+	Самый странный парадокс НЛП</h2>
 <p>
-	Ìû (ñâåæåâûïóùåííûå ÍËÏ-òðåíåðû) íå ïîíèìàëè &laquo;çàæðàâøèõñÿ&raquo; &laquo;ñòàðè÷êîâ&raquo;, êîòîðûå èìåëè ëó÷øåå ïîëîæåíèå â ÍËÏ-öåíòðàõ ÷åì ìû, íî ïîñòîÿííî áûëè ÷åì-òî íåäîâîëüíû. À çàòåì âñå-ðàâíî óõîäèëè â âîëüíîå ïëàâàíèå, ïîíèìàÿ, ÷òî òàì çàðàáîòîê áóäåò áîëüøå. Íî ÷åðåç ãîä-äâà ÷åðåç ýòî ïðîõîäèëè âñå. È òîãäà âîçíèêàë áîëøîé âîïðîñ: &laquo;À ÷åãî æäàòü-òî áûëî? Íåóæåëè íå î÷åâèäåí îáùèé ïàòòåðí?&raquo;<br />
+	Мы (свежевыпущенные НЛП-тренеры) не понимали &laquo;зажравшихся&raquo; &laquo;старичков&raquo;, которые имели лучшее положение в НЛП-центрах чем мы, но постоянно были чем-то недовольны. А затем все-равно уходили в вольное плавание, понимая, что там заработок будет больше. Но через год-два через это проходили все. И тогда возникал болшой вопрос: &laquo;А чего ждать-то было? Неужели не очевиден общий паттерн?&raquo;<br />
 	<br />
-	Æèçíü òðåíåðà ðàäèêàëüíî ìåíÿåòñÿ â òîò ìîìåíò, êîãäà îí óñâàèâàåò îäèí èç ñàìûõ ïåðâûõ óðîêîâ êóðñà ÍËÏ-ïðàêòèê. Âñÿ îòâåòñòâåííîñòü çà òâîè ðåçóëüòàòû ëåæèò íà òåáå ñàìîì. È åñëè òû ÍËÏ-òðåíåð, òî ïî÷åìó ó òåáÿ äî ñèõ ïîð íåò ñâîåãî òðåíèíãà, êîòîðûé çàõîòÿò ïðîäàâàòü âñå? (Ïîíÿòíî, ÷òî êîãäà òû åãî ñäåëàåøü, òî ñêîðåå âñåãî çàõî÷åøü ïðîäàâàòü åãî ñàì ;))<br />
+	Жизнь тренера радикально меняется в тот момент, когда он усваивает один из самых первых уроков курса НЛП-практик. Вся ответственность за твои результаты лежит на тебе самом. И если ты НЛП-тренер, то почему у тебя до сих пор нет своего тренинга, который захотят продавать все? (Понятно, что когда ты его сделаешь, то скорее всего захочешь продавать его сам ;))<br />
 	<br />
-	Â îáùåì, ñêëàäûâàåòñÿ äîâîëüíî ñòðàííàÿ ñèòóàöèÿ - âðîäå áû ÍËÏ ýòî ïðî ìîäåëèðîâàíèå ýôôåêòèâíîñòè. Íî, ïî÷åìó-òî ñìîäåëèðîâàòü ýôôåêòèâíûé çàðàáîòîê óäàëîñü äàæå íå êàæäîìó ÍËÏ-òðåíåðó. ×åãî æå òîãäà æäàòü îò ÍËÏ-ìàñòåðîâ? È êàê îáúÿñíèòü äðóãèì ëþäÿì, ÷òî ÍËÏ - ýòî ïðî óñïåõ è ýôôåêòèâíîñòü, êîãäà ñàïîæíèêè-òî áåç ñàïîã?</p>
+	В общем, складывается довольно странная ситуация - вроде бы НЛП это про моделирование эффективности. Но, почему-то смоделировать эффективный заработок удалось даже не каждому НЛП-тренеру. Чего же тогда ждать от НЛП-мастеров? И как объяснить другим людям, что НЛП - это про успех и эффективность, когда сапожники-то без сапог?</p>
 <h2>
-	Äâà ãëàâíûõ ïðàâèëà õîðîøåãî òðåíèíãà</h2>
+	Два главных правила хорошего тренинга</h2>
 <p>
-	Ïðîäàâàòü ÍËÏ-òðåíèíãè â íèøó óæå-ÍËÏåðîâ - èäåÿ ïðîñòàÿ, íî íà ïîðÿäîê (à òî è íà äâà) ìåíåå âûãîäíàÿ. (Ýòî, êñòàòè, âåðíî äëÿ ëþáîé íèøè.)</p>
+	Продавать НЛП-тренинги в нишу уже-НЛПеров - идея простая, но на порядок (а то и на два) менее выгодная. (Это, кстати, верно для любой ниши.)</p>
 <p>
-	Âî-ïåðâûõ, ïîòîìó ÷òî óæå-ÍËÏåðû - âåñüìà ìàëåíüêàÿ íèøà. Âî-âòîðûõ, ïîòîìó ÷òî îíà ïðåèìóùåñòâåííî áåäíàÿ. À â-òðåòüèõ, ïîòîìó ÷òî îíà ïðîôåññèîíàëüíàÿ è òðåáîâàòåëüíàÿ. Óæå-ÍËÏåðàì ìîæíî ïðîäàâàòü òîëüêî çâåçä ÍËÏ, äà è òî ñ òðóäîì - îíè äàæå èõ ðàñêðèòèêóþò âäðûçã, ÷òîáû ïîä÷åðêíóòü ñâîþ ÍËÏåðñêóþ ïðîôåññèîíàëüíîñòü (êàê, íàïðèìåð, ýòî áûëî íà ñåìèíàðå Ãðèíäåðà ïî Íîâîìó Êîäó ÍËÏ â 2004-ì.)</p>
+	Во-первых, потому что уже-НЛПеры - весьма маленькая ниша. Во-вторых, потому что она преимущественно бедная. А в-третьих, потому что она профессиональная и требовательная. Уже-НЛПерам можно продавать только звезд НЛП, да и то с трудом - они даже их раскритикуют вдрызг, чтобы подчеркнуть свою НЛПерскую профессиональность (как, например, это было на семинаре Гриндера по Новому Коду НЛП в 2004-м.)</p>
 <p>
-	Èíòåðåñóþùèõñÿ æå òåìîé (áåãèíåðîâ) âñåãäà áîëüøå, ÷åì òåõ, êòî óæå â òåìå. Ïîêóïàòåëüñêàÿ ñïîñîáíîñòü ó íèõ âûøå. È, ñàìîå ãëàâíîå, íà÷èíàþùåìó òðåíåðó íàìíîãî ïðîùå áûòü ýêñïåðòîì äëÿ íèõ, ÷åì äëÿ ïðîôåññèîíàëîâ. Âàì êàæåòñÿ, ÷òî ÿêîðÿ ýòî ïðîñòî - íî äëÿ áîëüøèíñòâà ëþäåé ýòî øàìàíñòâî òðåòüåãî óðîâíÿ. À âëàäåÿ ðàñêðóòêàìè è ìåòàïðîãðàììàìè óæå ìîæíî ñíèìàòü òîê øîó (÷òî è ñäåëàë Ñîëîâüåâ ;)).</p>
+	Интересующихся же темой (бегинеров) всегда больше, чем тех, кто уже в теме. Покупательская способность у них выше. И, самое главное, начинающему тренеру намного проще быть экспертом для них, чем для профессионалов. Вам кажется, что якоря это просто - но для большинства людей это шаманство третьего уровня. А владея раскрутками и метапрограммами уже можно снимать ток шоу (что и сделал Соловьев ;)).</p>
 <p>
-	È ñàìîå ãëàâíîå, ëþäÿì èçâíå ÍËÏ - ýòè ïðîñòûå èíñòðóìåíòû äåéñòâèòåëüíî íóæíû. È íå äëÿ áëåñêà, à äëÿ ðåøåíèÿ êîíêðåòíûõ çàäà÷. Çà êîòîðûå, êñòàòè, îíè ãîòîâû õîðîøî ïëàòèòü.</p>
+	И самое главное, людям извне НЛП - эти простые инструменты действительно нужны. И не для блеска, а для решения конкретных задач. За которые, кстати, они готовы хорошо платить.</p>
 <h4>
-	<em>Ïðàâèëî ïåðâîå: Òðåíèíã çàíèøåâàí</em></h4>
+	<em>Правило первое: Тренинг занишеван</em></h4>
 <p>
-	Ïðîäàâàòü òðåíèíã â îáùåé òåìå î÷åíü ñëîæíî. &laquo;ÍËÏ, ïîìîãàþùåå âñåì ðåøèòü âåçäå âñå ïðîáëåìû âî âñåì è íàâñåãäà&raquo; - íå ïðîäàåòñÿ. Òàê æå êàê è óñïåøíûé óñïåõ ðàäè óñïåõà â óñïåõàõ. Òàê æå, êàê è &laquo;ýôôåêòèâíàÿ ýôôåêòèâíîñòü&raquo;. Òàê æå êàê è &laquo;ðàçâèòèå ëè÷íîñòè&raquo; (×òî ðàçâèâàåì-òî? Íàâûê âÿçàíèÿ êðþ÷êîì?!)</p>
+	Продавать тренинг в общей теме очень сложно. &laquo;НЛП, помогающее всем решить везде все проблемы во всем и навсегда&raquo; - не продается. Так же как и успешный успех ради успеха в успехах. Так же, как и &laquo;эффективная эффективность&raquo;. Так же как и &laquo;развитие личности&raquo; (Что развиваем-то? Навык вязания крючком?!)</p>
 <p>
-	Ïîòîìó ÷òî íîðìàëüíîìó ÷åëîâåêó (íå èñïîð÷åííîìó ìèëòîí ìîäåëüþ) íèôèãà íåïîíÿòíî êîìó è çà÷åì ýòî íóæíî.</p>
+	Потому что нормальному человеку (не испорченному милтон моделью) нифига непонятно кому и зачем это нужно.</p>
 <p>
-	À òå ëþäè, êîòîðûì ÍËÏ èíòåðåñíî ïðîñòî êàê òåìà - ïîéäóò íà èçâåñòíûå èìåíà â ýòîé òåìå, è íà÷èíàþùåìó òðåíåðó ëîâèòü çäåñü ïðîñòî íå÷åãî.</p>
+	А те люди, которым НЛП интересно просто как тема - пойдут на известные имена в этой теме, и начинающему тренеру ловить здесь просто нечего.</p>
 <h4>
-	Ìîäåëèðóéòå òåõ, ó êîãî ïîëó÷àåòñÿ</h4>
+	Моделируйте тех, у кого получается</h4>
 <p>
-	Áûñòðîå îáó÷åíèå àíãëèéñêîìó ÿçûêó ñ ïîìîùüþ ÍËÏ - õîðîøåå ïîçèöèîíèðîâàíèå. Óïðàâëåíèå ýìîöèÿìè ñ ïîìîùüþ ÍËÏ äëÿ ðóêîâîäèòåëåé - òîæå. Ïîòîìó ÷òî ïîíÿòíî êàêóþ çàäà÷ó ðåøàåò òðåíèíã. È äëÿ êîãî. À çíà÷èò ÿñíî êîìó è êàê åãî ïðîäàâàòü.<br />
+	Быстрое обучение английскому языку с помощью НЛП - хорошее позиционирование. Управление эмоциями с помощью НЛП для руководителей - тоже. Потому что понятно какую задачу решает тренинг. И для кого. А значит ясно кому и как его продавать.<br />
 	<br />
-	Îáû÷íî ñëîâî &laquo;ÍËÏ&raquo; óáèðàþò èç íàçâàíèÿ. Ìîë, íå ïðèçíàåòñÿ îíî â ìàññàõ... Íî ñåé÷àñ, êîãäà äëÿ êàæäîé öåëåâîé àóäèòîðèè ñóùåñòâóåò îãðîìíîå êîëè÷åñòâî òðåíèíãîâ, íóæíî êàê-òî äèôôåðåíöèðîâàòüñÿ. Ñóæàòü ñâîþ íèøó äî ñóáíèøè, ÷òîáû íå êîíêóðèðîâàòü ñ òåìè, êòî óæå äàâíî â ýòîé òåìå. À êàê ìîæíî îáîéòè êîíêóðåíòîâ?</p>
+	Обычно слово &laquo;НЛП&raquo; убирают из названия. Мол, не признается оно в массах... Но сейчас, когда для каждой целевой аудитории существует огромное количество тренингов, нужно как-то дифференцироваться. Сужать свою нишу до субниши, чтобы не конкурировать с теми, кто уже давно в этой теме. А как можно обойти конкурентов?</p>
 <h4>
-	Ëó÷øå áûòü ¹1 ñðåäè ñîòíè ÷åëîâåê, ÷åì ¹10 ñðåäè òûñÿ÷è</h4>
+	Лучше быть №1 среди сотни человек, чем №10 среди тысячи</h4>
 <p>
-	Åñëè òåáå íå íóæíî êîíêóðèðîâàòü, òî òû ïðîñòî ïðèõîäèøü è áåðåøü ýòîò ðûíîê. À åñëè íóæíî, òî äàâàéòå îáúåêòèâíî - êàêîâû Âàøè øàíñû?</p>
+	Если тебе не нужно конкурировать, то ты просто приходишь и берешь этот рынок. А если нужно, то давайте объективно - каковы Ваши шансы?</p>
 <p>
-	Äà, ðûíîê ìîæåò áûòü íå áîëüøîé. Íî áûñòðî âçÿâ åãî, òû èäåøü è áåðåøü ñëåäóþùèé. À çàòåì ñëåäóþùèé. È âìåñòî òîãî ÷òîáû áèòüñÿ ñ êîíêóðåíòàìè, êîòîðûå ñèëüíåå òåáÿ, òû ìåòîäè÷íî &laquo;âûåäàåøü&raquo; ñâîþ ÷àñòü ïèðîãà ìàëåíüêèìè êóñî÷êàìè. Ñïîêîéíî, áåç áîðüáû, áåç ãîíêè çà ïîïóëÿðíîñòüþ - ïðîñòî äåëàÿ ñâîå äåëî. È ïîïóëÿðíîñòü ðàñòåò çà òîáîé ñëåäîì, ïî ìåðå òîãî, êàê &laquo;ñúåäåííàÿ îáëàñòü ïèðîãà&raquo; ñòàíîâèòñÿ âñå áîëüøå è áîëüøå. Ïîýòîìó òî÷íîñòü è ñêîðîñòü ðåøàþò.</p>
+	Да, рынок может быть не большой. Но быстро взяв его, ты идешь и берешь следующий. А затем следующий. И вместо того чтобы биться с конкурентами, которые сильнее тебя, ты методично &laquo;выедаешь&raquo; свою часть пирога маленькими кусочками. Спокойно, без борьбы, без гонки за популярностью - просто делая свое дело. И популярность растет за тобой следом, по мере того, как &laquo;съеденная область пирога&raquo; становится все больше и больше. Поэтому точность и скорость решают.</p>
 <h4>
-	À åñòü ëè íèøà?</h4>
+	А есть ли ниша?</h4>
 <p>
-	Ñàìàÿ ÷àñòàÿ è ñàìàÿ áîëüøàÿ îøèáêà, êîòîðàÿ òóò âñòðå÷àåòñÿ - ýòî ïðèäóìûâàíèå íèøè. Åå íå íàäî ïðèäóìûâàòü - åå íàäî íàéòè. È çàòåì ïðîòåñòèðîâàòü íà ñïðîñ ïåðâè÷íîé ïðîäàæåé. Èíà÷å âåñü Âàø òðóä ìîæåò îêàçàòüñÿ íàïðàñåí.<br />
+	Самая частая и самая большая ошибка, которая тут встречается - это придумывание ниши. Ее не надо придумывать - ее надо найти. И затем протестировать на спрос первичной продажей. Иначе весь Ваш труд может оказаться напрасен.<br />
 	<br />
-	Òî åñòü ïðàâèëî òàêîå - ñíà÷àëà íàõîäèøü íèøó è ïðîäàåøü â íåå, à ïîòîì óæå íà÷èíàåøü ðàçðàáîòêó.</p>
+	То есть правило такое - сначала находишь нишу и продаешь в нее, а потом уже начинаешь разработку.</p>
 <p>
-	Äåëî äàæå íå â ýêîíîìèè ñèë è âðåìåíè. Äåëî â òîì, ÷òîáû ðàçðàáàòûâàòü òî, ÷òî ãàðàíòèðîâàííî íóæíî ëþäÿì. À íå òî, ÷òî ïîêàçàëîñü Âàì ïîëåçíûì â ñèëó ëè÷íîé èñòîðèè è äåòñêèõ èìïðèíòîâ.<br />
+	Дело даже не в экономии сил и времени. Дело в том, чтобы разрабатывать то, что гарантированно нужно людям. А не то, что показалось Вам полезным в силу личной истории и детских импринтов.<br />
 	<br />
-	<strong>P.S. </strong>Ïî ïîèñêó ñâîåé íèøè, êñòàòè, åñòü îòëè÷íàÿ ìåòîäè÷êà. Åå ìîæíî ñêà÷àòü ó ìåíÿ íà ñàéòå ñîâåðøåííî áåñïëàòíî.</p>
+	<strong>P.S. </strong>По поиску своей ниши, кстати, есть отличная методичка. Ее можно скачать у меня на сайте совершенно бесплатно.</p>
 <h3>
-	<em>Ïðàâèëî âòîðîå: Ëåñòíèöà ïðîäóêòîâ</em></h3>
+	<em>Правило второе: Лестница продуктов</em></h3>
 <p>
-	Íå íóæíî òåñòèðîâàòü íèøó ñðàçó äîðîãèì òðåíèíãîì. Ïðè÷èíû, äóìàþ, ïîíÿòíû. Ê òîìó æå, ÷åì ëåã÷å Âû ñäåëàåòå &laquo;âõîä&raquo; äëÿ ñâîèõ êëèåíòîâ, òåì ëó÷øå áóäåò âàì âñåì.<br />
+	Не нужно тестировать нишу сразу дорогим тренингом. Причины, думаю, понятны. К тому же, чем легче Вы сделаете &laquo;вход&raquo; для своих клиентов, тем лучше будет вам всем.<br />
 	<br />
-	Åñëè Âû ñïåö â òåìå, òî ëåãêî ðàçîáüåòå îáó÷åíèå åé íà íåñêîëüêî ñòóïåíåé:</p>
+	Если Вы спец в теме, то легко разобьете обучение ей на несколько ступеней:</p>
 <h4>
-	Ïåðâàÿ ñòóïåíü: òåñòèðîâàíèå è ëåãêèé âõîä&#8232;</h4>
+	Первая ступень: тестирование и легкий вход&#8232;</h4>
 <p>
-	5-10 ñàìûõ ñèëüíûõ &laquo;ôèøåê&raquo; èç Âàøåãî àðñåíàëà, ñ ïîìîùüþ êîòîðûõ êàêèå-òî êîíêðåòíûå ëþäè ñìîãóò óæå ñðàçó ðåøèòü êàêèå-òî êîíêðåòíûå ñâîè çàäà÷è. È, òàêèì îáðàçîì, &laquo;ïîïðîáîâàòü&raquo;, òî ëè ýòî, ÷òî èì íóæíî. À Âû - ïðîòåñòèðîâàòü, ïîëüçóåòñÿ ëè ýòî ñïðîñîì.<br />
+	5-10 самых сильных &laquo;фишек&raquo; из Вашего арсенала, с помощью которых какие-то конкретные люди смогут уже сразу решить какие-то конкретные свои задачи. И, таким образом, &laquo;попробовать&raquo;, то ли это, что им нужно. А Вы - протестировать, пользуется ли это спросом.<br />
 	<br />
-	Ýòî ìîæåò áûòü äåøåâûé âå÷åðíèé ìàñòåð-êëàññ, áåñïëàòíûé âåáèíàð èëè âîîáùå âèäåî-óðîê íà þòóáå, ïðåäëàãàåìûé â îáìåí íà êîíòàêòû. Åñëè ÷åëîâåê ãîòîâ õîòÿ áû îñòàâèòü Âàì ñâîè êîíòàêòû - çíà÷èò Âû åìó äåéñòâèòåëüíî èíòåðåñíû. Åñëè íå ãîòîâ ñäåëàòü äàæå ýòî - íèøè ñêîðåå âñåãî íåò.<br />
+	Это может быть дешевый вечерний мастер-класс, бесплатный вебинар или вообще видео-урок на ютубе, предлагаемый в обмен на контакты. Если человек готов хотя бы оставить Вам свои контакты - значит Вы ему действительно интересны. Если не готов сделать даже это - ниши скорее всего нет.<br />
 	<br />
-	Íó è, êðîìå òîãî, ïîëó÷èâ êîíòàêòû ïîòåíöèàëüíûõ êëèåíòîâ, Âû ñìîæåòå ñîîáùèòü èì î ñëåäóþùåì ñâîåì òðåíèíãå.</p>
+	Ну и, кроме того, получив контакты потенциальных клиентов, Вы сможете сообщить им о следующем своем тренинге.</p>
 <h4>
-	Âòîðàÿ ñòóïåíü: áàçîâûå íàâûêè</h4>
+	Вторая ступень: базовые навыки</h4>
 <p>
-	Òðåíèíã, ñäåëàííûé ÊÀÊ äëÿ íà÷èíàþùèõ. Íà íåì Âû äàåòå âñþ íåîáõîäèìóþ áàçó ñ íóëÿ. ×òîáû âî-ïåðâûõ, ëþäè óæå íà÷àëè ïîëó÷àòü ðåçóëüòàòû. È âî-âòîðûõ - ïîëó÷èëè íàûêè, íåîáõîäèìûå äëÿ äâèæåíèÿ äàëüøå. Â ïîñëåäñòâèè ýòîò òðåíèíã ñòàíåò ïåðâûì ìîäóëåì Âàøåãî êóðñà, íî ïîêà ïóñòü ýòî áóäåò ïðîñòî òðåíèíã.</p>
+	Тренинг, сделанный КАК для начинающих. На нем Вы даете всю необходимую базу с нуля. Чтобы во-первых, люди уже начали получать результаты. И во-вторых - получили наыки, необходимые для движения дальше. В последствии этот тренинг станет первым модулем Вашего курса, но пока пусть это будет просто тренинг.</p>
 <p>
-	<strong>P.S.</strong> Íå ïîëåíèòåñü, çàñíèìèòå åãî íà êàìåðó. È âîîáùå - öèôðóéòå âñå ÷òî âû äåëàåòå. Àáñîëþòíî âñå. Âû äàæå íå ïðåäñòàâëÿåòå ñåé÷àñ, êàê ýòî ïðèãîäèòñÿ Âàì çàâòðà.</p>
+	<strong>P.S.</strong> Не поленитесь, заснимите его на камеру. И вообще - цифруйте все что вы делаете. Абсолютно все. Вы даже не представляете сейчас, как это пригодится Вам завтра.</p>
 <h4>
-	Âòîðàÿ ñòóïåíü+ (ñåêðåò VIP-áëîêà)</h4>
+	Вторая ступень+ (секрет VIP-блока)</h4>
 <p>
-	Åñëè ñâîåé àóäèòîðèè Âû õîòèòå äàòü è ïîäâèíóòóþ ïðîãðàììó òîæå (èëè åå ÷àñòü), íå ñòîèò îòêëàäûâàòü äî ñëåäóþùåãî òðåíèíãà. Äîáàâüòå ê ñâîåìó òðåíèíãó åùå îäíèì äíåì ìàñòåð-áëîê èëè VIP-äåíü. È âêëþ÷èòå â íåãî òå ôèøêè, êîòîðûå ìîæåò îñâîèòü òîëüêî ñàìàÿ ïðîäâèíóòàÿ ÷àñòü Âàøåé ãðóïïû. Ñòîèìîñòü ñäåëàéòå òàêóþ æå, êàê è íà îñíîâíóþ ïðîãðàììó. È ïîñòàâüòå â ðàñïèñàíèå ñðàçó ïîñëå îñíîâíîé ïðîãðàììû - ñëåäóþùèì äíåì.<br />
+	Если своей аудитории Вы хотите дать и подвинутую программу тоже (или ее часть), не стоит откладывать до следующего тренинга. Добавьте к своему тренингу еще одним днем мастер-блок или VIP-день. И включите в него те фишки, которые может освоить только самая продвинутая часть Вашей группы. Стоимость сделайте такую же, как и на основную программу. И поставьте в расписание сразу после основной программы - следующим днем.<br />
 	<br />
-	Ïî ñòàòèñòèòå 50-60% ó÷àñòíèêîâ ìîãóò è õîòÿò åãî ïðîéòè, åñëè ýòî ìîæíî ñäåëàòü ñðàçó. Ê òîìó æå, ýòî áóäåò çíà÷èòåëüíî óäîáíåå äëÿ òåõ, êòî ïðèåçæàåò íà Âàø òðåíèíã èç äðóãîãî ãîðîäà è òðàòèò íà áèëåòû áîëüøå, ÷åì íà îïëàòó âñåãî Âàøåãî òðåíèíãà öåëèêîì.<br />
+	По статистите 50-60% участников могут и хотят его пройти, если это можно сделать сразу. К тому же, это будет значительно удобнее для тех, кто приезжает на Ваш тренинг из другого города и тратит на билеты больше, чем на оплату всего Вашего тренинга целиком.<br />
 	<br />
-	Òîëüêî î÷åíü âàæíî ñïëàíèðîâàòü è ïðîâåñòè îñíîâíóþ ïðîãðàììó è VIP-áëîê êàê äâà îòäåëüíûõ òðåíèíãà.</p>
+	Только очень важно спланировать и провести основную программу и VIP-блок как два отдельных тренинга.</p>
 <h4>
-	Êàê óâåëè÷èòü ïðîäàæè óæå ñòîÿùåãî â ðàñïèñàíèè òðåíèíãà åùå â ïîëòîðà ðàçà</h4>
+	Как увеличить продажи уже стоящего в расписании тренинга еще в полтора раза</h4>
 <p>
-	Åñëè ó Âàñ óæå îáúÿâëåí êàêîé-ëèáî òðåíèíã â ðàñïèñàíèè, Âû ìîæåòå ïðÿìî ñåé÷àñ ñäåëàòü äëÿ íåãî VIP-áëîê è îáúÿâèòü î íåì âñåì çàðåãèñòðèðîâàâøèìñÿ ó÷àñòíèêàì. Ñäåëàéòå õîðîøóþ ñêèäêó ïåðâûì êóïèâøèì VIP-áëîê çà îêàçàííîå Âàì äîâåðèå.<br />
+	Если у Вас уже объявлен какой-либо тренинг в расписании, Вы можете прямо сейчас сделать для него VIP-блок и объявить о нем всем зарегистрировавшимся участникам. Сделайте хорошую скидку первым купившим VIP-блок за оказанное Вам доверие.<br />
 	<br />
-	Ñðàçó æå Âû çàìåòèòå åùå îäèí èíòåðåñíûé ôàêò. Êàê òîëüêî ó Âàñ ïîÿâèòñÿ VIP-áëîê, îñíîâíàÿ ïðîãðàììà íà÷íåò ïðîäàâàòüñÿ ëó÷øå. Ïî÷åìó - ïîäóìàéòå ñàìè, âòîðàÿ ïîçèöèÿ Âàì â ïîìîùü ;)</p>
+	Сразу же Вы заметите еще один интересный факт. Как только у Вас появится VIP-блок, основная программа начнет продаваться лучше. Почему - подумайте сами, вторая позиция Вам в помощь ;)</p>
 <h4>
-	Òðåòüÿ ñòóïåíü: óâåëè÷èíèå ïðèáûëè ñ êàæäîãî òðåíèíãà â 4 ðàçà</h4>
+	Третья ступень: увеличиние прибыли с каждого тренинга в 4 раза</h4>
 <p>
-	Ïðî òðåòüþ ñòóïåíü ÿ çäåñü ðàññêàçûâàòü íå áóäó. Ïðîñòî íåò ñìûñëà, åñëè Âû åùå íå âíåäðèëè ïåðâûå äâå. È òåì áîëåå, åñëè ó Âàñ íåò ñâîåãî òðåíèíãà. Íî â äâóõ ñëîâàõ ñêàæó î ÷åì îíà.<br />
+	Про третью ступень я здесь рассказывать не буду. Просто нет смысла, если Вы еще не внедрили первые две. И тем более, если у Вас нет своего тренинга. Но в двух словах скажу о чем она.<br />
 	<br />
-	Âûðó÷êà ñ ïðîäàæè ó÷àñòèÿ â òðåíèíãå - ýòî òîëüêî 25% ïðèáûëè, êîòîðóþ Âû ìîæåòå èìåòü. Îñòàëüíûå 75% ìîæíî î÷åíü ëåãêî ïîëó÷èòü, äîáàâèâ ê ñâîèì òðåíåðñêèì äâèæåíèÿì âñåãî 3 ïðîñòûå äåéñòâèÿ (â ðàìêàõ òîãî æå òðåíèíãà). Íî îá ýòîì íå çäåñü è íå ñåé÷àñ.</p>
+	Выручка с продажи участия в тренинге - это только 25% прибыли, которую Вы можете иметь. Остальные 75% можно очень легко получить, добавив к своим тренерским движениям всего 3 простые действия (в рамках того же тренинга). Но об этом не здесь и не сейчас.</p>
 <p>
-	<strong>P.S.</strong> Îá ýòîì ÿ ðàññêàçàë â ñâîåì <a href="indexd330.html?id=F4A15">áåïëàòíîì âåáèíàðå ïî ïðîäàæå ÍËÏ-òðåíèíãîâ</a>.</p>
+	<strong>P.S.</strong> Об этом я рассказал в своем <a href="indexd330.html?id=F4A15">беплатном вебинаре по продаже НЛП-тренингов</a>.</p>
 <p style="text-align: right">
-	<em>Åãîð Áóëûãèí,&#8232;<br />
-	êîó÷ ïî ïðîäàæå òðåíèíãîâ</em></p>
+	<em>Егор Булыгин,&#8232;<br />
+	коуч по продаже тренингов</em></p>
 <p>
-	<strong>P.P.S.</strong> Åñëè Âû ñ÷èòàåòå ýòîò ìàòåðèàë ïîëåçíûì,<br />
-	ïîìîãèòå, ïîæàëóéñòà åãî ðàñïðîñòðàíèòü:</p>
+	<strong>P.P.S.</strong> Если Вы считаете этот материал полезным,<br />
+	помогите, пожалуйста его распространить:</p>
 <p style="text-align: center">
 	<a name='vote'></a><script type='text/javascript'>
 function light(num){
@@ -536,16 +536,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup9a0d.html?id=F4A18&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupcac1.html?id=F4A18&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup1959.html?id=F4A18&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup3921.html?id=F4A18&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupe9d3.html?id=F4A18&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup9a0d.html?id=F4A18&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupcac1.html?id=F4A18&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup1959.html?id=F4A18&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup3921.html?id=F4A18&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupe9d3.html?id=F4A18&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -568,12 +568,12 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div> <div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Äëÿ ÍËÏåðîâ&quot;</p> <ul><li><a href='F4A2A.html' title='5 îøèáîê ïðè ïðîäàæå òðåíèíãîâ, íå ïîçâîëÿþùèå âûéòè íà íîâûé óðîâåíü'>5 îøèáîê, "óáèâàþùèå" ïðîäàæè òðåíèíãîâ</a></li><li><a href='F4AF1.html' title=''>Ýòàïû ðàçâèòèÿ òðåíåðîâ</a></li><li><a href='F4AF4.html' title=''>Äëÿ ÷åãî íóæåí ìàðêåòèíã</a></li><li><a href='F4AF5.html' title='Â ýòîì âûïóñêå î òîì, êàê ïðàâèëüíî ñòðîèòü ñâîþ ìàðêåòèíãîâóþ ëèíåéêó è âçàèìîäåéñòâîâàòü ñ êëèåíòîì. '>Ìàðêåòèíãîâàÿ ëèíåéêà è ìåòîäèêà ñòóïåíåê</a></li><li><a href='F4AF3.html' title='×òî òàêîå "Ìàðêåòèíãîâûé êâàäðàíò"? Êàê è êîãäà èñïîëüçîâàòü ïðèåì "Èñòîðèè" èëè "Êà÷åëè"? Îá ýòîì â îäíîì èç êóñî÷êîâ "Òðåíèíãà íà ìèëëèîí".'>Ìàðêåòèíãîâûé êâàäðàíò</a></li></ul></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<!-- AddThis Button END --></div> <div class='relateditems'><p>Лучшие материалы раздела &quot;Для НЛПеров&quot;</p> <ul><li><a href='F4A2A.html' title='5 ошибок при продаже тренингов, не позволяющие выйти на новый уровень'>5 ошибок, "убивающие" продажи тренингов</a></li><li><a href='F4AF1.html' title=''>Этапы развития тренеров</a></li><li><a href='F4AF4.html' title=''>Для чего нужен маркетинг</a></li><li><a href='F4AF5.html' title='В этом выпуске о том, как правильно строить свою маркетинговую линейку и взаимодействовать с клиентом. '>Маркетинговая линейка и методика ступенек</a></li><li><a href='F4AF3.html' title='Что такое "Маркетинговый квадрант"? Как и когда использовать прием "Истории" или "Качели"? Об этом в одном из кусочков "Тренинга на миллион".'>Маркетинговый квадрант</a></li></ul></div> 
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A18" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -611,12 +611,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -640,8 +640,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -649,11 +649,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -712,7 +712,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -734,7 +734,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A29.html
+++ b/F4A29.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A29 by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:13:31 GMT -->
 <head>
-        <title>Áàçîâûå ôàêòîðû óñïåøíîãî ìàðêåòèíãà</title>
+        <title>Базовые факторы успешного маркетинга</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="Áåç ÷åãî íå îáîéòèñü â ïîñòðîåíèè ïðèáûëüíîãî áèçíåñà? Ðå÷ü ïîéäåò íå òîëüêî î íîâè÷êàõ â ìàëîì áèçíåñå..." />
+        <meta name="description" content="Без чего не обойтись в построении прибыльного бизнеса? Речь пойдет не только о новичках в малом бизнесе..." />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='F48A6.html'>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</a> </span> / Áàçîâûå ôàêòîðû óñïåøíîãî ìàðêåòèíãà                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='F48A6.html'>Бизнес, маркетинг и продажи</a> </span> / Базовые факторы успешного маркетинга                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,94 +399,94 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print5bd1.html?id=F4A29"><img src="images/printer.jpg"></a></div>
-                                    <h1>Áàçîâûå ôàêòîðû óñïåøíîãî ìàðêåòèíãà</h1>
+                                    <h1>Базовые факторы успешного маркетинга</h1>
                                                                     <p>
                                         <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 18px;"><strong>Áàçîâûå ôàêòîðû óñïåøíîãî ìàðêåòèíãà</strong></span></p>
+	<span style="font-size: 18px;"><strong>Базовые факторы успешного маркетинга</strong></span></p>
 <p>
-	<span style="font-size: 14px;">Îáùèå ïðèíöèïû è ìåõàíèçìû ïðîäàæ âåçäå îäèíàêîâû, èõ íóæíî çíàòü îáÿçàòåëüíî, áåç íèõ ëó÷øå â ïðèíöèïå íå íà÷èíàòü áèçíåñ.</span></p>
+	<span style="font-size: 14px;">Общие принципы и механизмы продаж везде одинаковы, их нужно знать обязательно, без них лучше в принципе не начинать бизнес.</span></p>
 <p>
 	&nbsp;</p>
 <h1>
-	<span style="font-size: 18px;"><strong>Ôàêòîð ïåðâûé &ndash; íèøà</strong></span></h1>
+	<span style="font-size: 18px;"><strong>Фактор первый &ndash; ниша</strong></span></h1>
 <p>
-	<span style="font-size: 14px;">Âû çíàåòå, êòî Âàøè êëèåíòû è çíàåòå, êàêèì îáðàçîì ïðîäàâàòü èì ñâîè ïðîäóêòû è óñëóãè, òîëüêî åñëè ïîíèìàåòå, ÷òî åñòü Âàøà íèøà. Òîãäà Âû ïîíèìàåòå, ãäå íàéòè ýòèõ êëèåíòîâ, êàêèì îáðàçîì èì ïðîäàâàòü, êàê ñîñòàâèòü ðåêëàìó.</span></p>
-<p>
-	&nbsp;</p>
-<p>
-	<span style="font-size: 14px;">Åñëè Âû íå çíàåòå, êòî âàøà íèøà &ndash; òîãäà âèäèìî ñòîèò íà÷àòü âñå ñ íîëÿ è ïîäóìàòü. Ïëîõàÿ íîâîñòü äëÿ òåõ, êòî óæå ÷òî-òî ïðîäàåò, çàêëþ÷àåòñÿ â òîì, ÷òî áîëüøèíñòâî ïðîäàþò îò ïðîäóêòà.</span></p>
+	<span style="font-size: 14px;">Вы знаете, кто Ваши клиенты и знаете, каким образом продавать им свои продукты и услуги, только если понимаете, что есть Ваша ниша. Тогда Вы понимаете, где найти этих клиентов, каким образом им продавать, как составить рекламу.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Åñòü íåêèé ïðîäóêò, &nbsp;è Âû äóìàåòå, ÷òî åãî áóäóò ïîêóïàòü. Âû èäåòå îò íåãî, à ÷àñòî ýòî íå ñðàáàòûâàåò, ïîòîìó ÷òî åñëè íèøà íå áûëà èçíà÷àëüíî ïîäåëåíà, òî Âû íà÷èíàåòå ïðîäàâàòü ñâîé ïðîäóêò âñåì &ndash; à çíà÷èò, íèêîìó! È â ðåçóëüòàòå ïðîäàæè ïðîèñõîäÿò êîå-êàê è êîå-ãäå.</span></p>
+	<span style="font-size: 14px;">Если Вы не знаете, кто ваша ниша &ndash; тогда видимо стоит начать все с ноля и подумать. Плохая новость для тех, кто уже что-то продает, заключается в том, что большинство продают от продукта.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Îïðåäåëèòå ñâîþ íèøó, ñîñòàâüòå îïèñàíèå Âàøèõ êëèåíòîâ. Âû áóäåòå çíàòü èõ ïðèâû÷êè, ÷òî îíè ïîêóïàþò, â êàêèå ìàãàçèíû îäåæäû çàõîäÿò, ãäå ïðåäïî÷èòàþò ãóëÿòü &ndash; è Âû áóäåòå çíàòü èõ ìîòèâàöèþ.</span></p>
+	<span style="font-size: 14px;">Есть некий продукт, &nbsp;и Вы думаете, что его будут покупать. Вы идете от него, а часто это не срабатывает, потому что если ниша не была изначально поделена, то Вы начинаете продавать свой продукт всем &ndash; а значит, никому! И в результате продажи происходят кое-как и кое-где.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 18px;"><strong>Ôàêòîð âòîðîé &ndash; ëåñòíèöà ïðîäàæ</strong></span></p>
-<p>
-	<span style="font-size: 14px;">Ãëàâíàÿ çàäà÷à ëåñòíèöû ïðîäàæ çàêëþ÷àåòñÿ â òîì, ÷òîáû ñäåëàòü ëåãêèé âõîä â Âàøè êëèåíòû ÷åëîâåêó ñ óëèöû. Ëåãêèé âõîä â âàøè êëèåíòû ïîñïîñîáñòâóåò ðîñòó åãî ïîêóïîê.</span></p>
+	<span style="font-size: 14px;">Определите свою нишу, составьте описание Ваших клиентов. Вы будете знать их привычки, что они покупают, в какие магазины одежды заходят, где предпочитают гулять &ndash; и Вы будете знать их мотивацию.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Êëèåíòà äåéñòâèòåëüíî äîðîãî ïðèâëå÷ü, íî óäåðæàòü åãî ãîðàçäî äåøåâëå. Ìíîãèå âêëàäûâàåò áîëüøîå êîëè÷åñòâî äåíåã íà ïðèâëå÷åíèå êëèåíòà òîëüêî ïîòîìó, ÷òî îíè çíàþò, ÷òî îíè ïîëó÷àò ñ íåãî íàìíîãî áîëüøå, îí ïðàêòè÷åñêè &laquo;êîðìèò&raquo; èõ â äàëüíåéøåì.</span></p>
+	<span style="font-size: 18px;"><strong>Фактор второй &ndash; лестница продаж</strong></span></p>
+<p>
+	<span style="font-size: 14px;">Главная задача лестницы продаж заключается в том, чтобы сделать легкий вход в Ваши клиенты человеку с улицы. Легкий вход в ваши клиенты поспособствует росту его покупок.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Ãëàâíàÿ ôèøêà ëåñòíèöû ïðîäàæ &ndash; Âàøà çàäà÷à íå ïîëó÷èòü ñ êëèåíòà ìàêñèìóì äåíåã çà ïåðâóþ èëè âòîðóþ ïîêóïêó, à ïîëó÷èòü ñ êëèåíòà ìàêñèìóì äåíåã çà ãîä èëè øåñòü ìåñÿöåâ, òî åñòü îðèåíòèðóéòåñü íà òî, ÷òî Âû ìîæåòå ïîëó÷èòü ñ êëèåíòà â äîëãîñðî÷íîé ïåðñïåêòèâå.</span></p>
+	<span style="font-size: 14px;">Клиента действительно дорого привлечь, но удержать его гораздо дешевле. Многие вкладывает большое количество денег на привлечение клиента только потому, что они знают, что они получат с него намного больше, он практически &laquo;кормит&raquo; их в дальнейшем.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Äëÿ óäåðæàíèÿ êëèåíòà è äîëãîñðî÷íîé ðàáîòû ñ íèì Âû äîëæíû èìåòü ïðàâèëüíóþ ëèíåéêó ïðîäóêòîâ. Áåç ëèíåéêè ïðîäóêòîâ âåðîÿòíîñòü òîãî, ÷òî Âàø áèçíåñ áóäåò ðàáîòàòü, î÷åíü ìàëåíüêàÿ.</span></p>
+	<span style="font-size: 14px;">Главная фишка лестницы продаж &ndash; Ваша задача не получить с клиента максимум денег за первую или вторую покупку, а получить с клиента максимум денег за год или шесть месяцев, то есть ориентируйтесь на то, что Вы можете получить с клиента в долгосрочной перспективе.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 18px;"><strong>Ôàêòîð òðåòèé - êëèåíòñêàÿ áàçà. </strong></span></p>
-<p>
-	<span style="font-size: 14px;">Ìíîãèå äóìàþò, ÷òî êëèåíòñêàÿ áàçà &ndash; ýòî ôèøêà òðåíèíãîâîãî áèçíåñà, íî ýòî äàëåêî íå òàê. Åñòü ëè ó Âàñ êàðòî÷êè ñêèäîê? Äà - ýòî çíà÷èò, ÷òî Âû åñòü â êëèåíòñêèõ áàçàõ ìíîãèõ êîìïàíèé.</span></p>
+	<span style="font-size: 14px;">Для удержания клиента и долгосрочной работы с ним Вы должны иметь правильную линейку продуктов. Без линейки продуктов вероятность того, что Ваш бизнес будет работать, очень маленькая.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Ïîëó÷èòü êëèåíòñêóþ áàçó ìîæíî ðàçíûìè ñïîñîáàìè, íà÷èíàÿ îò ðàçëè÷íûõ äèñêîíòíûõ êàðò è ïðåäëîæåíèé ïî àêöèÿì. Áîëåå èíòåðåñíûé ñïîñîá &ndash; ïðåäîñòàâëåíèå áåñïëàòíûõ ïðîäóêòîâ, áåñïëàòíûõ óñëóã èëè áåñïëàòíûõ ñåðâèñîâ.</span></p>
+	<span style="font-size: 18px;"><strong>Фактор третий - клиентская база. </strong></span></p>
+<p>
+	<span style="font-size: 14px;">Многие думают, что клиентская база &ndash; это фишка тренингового бизнеса, но это далеко не так. Есть ли у Вас карточки скидок? Да - это значит, что Вы есть в клиентских базах многих компаний.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Êàê òîëüêî Âû ïîëó÷èëè êëèåíòà, ðåàëüíî ñ÷èòàéòå, ÷òî Âû çàïëàòèëè çà íåãî î÷åíü äîðîãî. È äàëüøå Âàøà çàäà÷à &ndash; ðàáîòàòü ñ ýòèì êëèåíòîì. Êîðìèòü íóæíî òó ëîøàäü, êîòîðàÿ Âàñ âåçåò, à íå òó, êîòîðàÿ ãäå-òî ïàñåòñÿ, è ïîòåíöèàëüíî ìîæåò ñòàòü Âàøåé.</span></p>
+	<span style="font-size: 14px;">Получить клиентскую базу можно разными способами, начиная от различных дисконтных карт и предложений по акциям. Более интересный способ &ndash; предоставление бесплатных продуктов, бесплатных услуг или бесплатных сервисов.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 18px;"><strong>×åòâåðòûé ôàêòîð &ndash; óäâîåíèå ïðîäàæ</strong></span></p>
-<p>
-	<span style="font-size: 14px;">Êîãäà ó Âàñ óæå åñòü áèçíåñ, âñå èäåò ÷åòêî, íî ðåàëüíî áîëüøàÿ íîâîñòü â òîì, ÷òî Âû íå äîáèðàåòå ïîðÿäêà 50%, à òî è 70% òîãî, ÷òî Âû ìîæåòå èìåòü.</span></p>
+	<span style="font-size: 14px;">Как только Вы получили клиента, реально считайте, что Вы заплатили за него очень дорого. И дальше Ваша задача &ndash; работать с этим клиентом. Кормить нужно ту лошадь, которая Вас везет, а не ту, которая где-то пасется, и потенциально может стать Вашей.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Êàêèì îáðàçîì Âû ìîæåòå ýòî èçìåíèòü? &nbsp;Ó Âàñ óæå åñòü êëèåíòû, êîòîðûå ó Âàñ óæå ÷òî-òî ïîêóïàþò, ó Âàñ óæå åñòü ëèíåéêà, òî åñòü ìàðêåòèíã ïðîñòðîåí, Âû ïîíèìàåòå, êàê âû ïðèâëåêàåòå êëèåíòîâ, ÷òî åñòü Âàøà íèøà, ÷òî Âû ïðîäàåòå âíà÷àëå, íà ÷åì Âû çàðàáàòûâàåòå.</span></p>
+	<span style="font-size: 18px;"><strong>Четвертый фактор &ndash; удвоение продаж</strong></span></p>
+<p>
+	<span style="font-size: 14px;">Когда у Вас уже есть бизнес, все идет четко, но реально большая новость в том, что Вы не добираете порядка 50%, а то и 70% того, что Вы можете иметь.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">È òîãäà âîçíèêàåò âîïðîñ &ndash; äîñòàòî÷íî ëè äåíåã Âû èç ýòîãî âûòàñêèâàåòå èëè ìîæåò áûòü, ãäå-òî ÷òî-òî ïðîäàåòå íåäîñòàòî÷íî õîðîøî.</span></p>
+	<span style="font-size: 14px;">Каким образом Вы можете это изменить? &nbsp;У Вас уже есть клиенты, которые у Вас уже что-то покупают, у Вас уже есть линейка, то есть маркетинг простроен, Вы понимаете, как вы привлекаете клиентов, что есть Ваша ниша, что Вы продаете вначале, на чем Вы зарабатываете.</span></p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">Îäíîé èç ôèøåê, ñïîñîáíîé óâåëè÷èòü ïðèáûëü â íåñêîëüêî ðàç, ÿâëÿåòñÿ Upsale&ndash; ïðîäàæà ïîñëå ïðîäàæè. Ìîìåíò ýòîò íàñòàåò, êîãäà Âû ÷òî-òî ïðîäàåòå êëèåíòó, òîëüêî ÷òî êóïèâøåìó ó Âàñ ïðîäóêò.</span></p>
+	<span style="font-size: 14px;">И тогда возникает вопрос &ndash; достаточно ли денег Вы из этого вытаскиваете или может быть, где-то что-то продаете недостаточно хорошо.</span></p>
+<p>
+	&nbsp;</p>
+<p>
+	<span style="font-size: 14px;">Одной из фишек, способной увеличить прибыль в несколько раз, является Upsale&ndash; продажа после продажи. Момент этот настает, когда Вы что-то продаете клиенту, только что купившему у Вас продукт.</span></p>
 <p>
 	&nbsp;</p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 14px;">ß ðàññêàçàë î áàçå, áåç êîòîðîé íåâîçìîæíî â ïðèíöèïå íà÷àòü áèçíåñ. Ñ ñàìûìè äåéñòâåííûìè ñòðàòåãèÿìè íà îñíîâå ýòîé áàçû ÿ áóäó äåëèòüñÿ óæå î÷åíü ñêîðî, íà æèâîì òðåíèíãå &laquo;Äåíåæíûé èíòåëëåêò&raquo;. </span></p>
+	<span style="font-size: 14px;">Я рассказал о базе, без которой невозможно в принципе начать бизнес. С самыми действенными стратегиями на основе этой базы я буду делиться уже очень скоро, на живом тренинге &laquo;Денежный интеллект&raquo;. </span></p>
 <p>
-	<span style="font-size: 14px;">Â íåáîëüøîé ìåòîäè÷êå <a href="indexba20.html?id=6strategiybusiness">&quot;6 ìåòîäîâ óäâîåíèÿ ïðîäàæ ñ ïîìîùüþ ÍËÏ&quot; </a>ÿ îïèñàë ìåòîäû, ýôôåêòèâíî ðàáîòàþùèå íà áàçîâûõ ôàêòîðàõ.</span></p>
+	<span style="font-size: 14px;">В небольшой методичке <a href="indexba20.html?id=6strategiybusiness">&quot;6 методов удвоения продаж с помощью НЛП&quot; </a>я описал методы, эффективно работающие на базовых факторах.</span></p>
 <p style="text-align: right;">
 	&nbsp;</p>
 <p style="text-align: right;">
-	Åãîð Áóëûãèí</p>
+	Егор Булыгин</p>
 <p style="text-align: right;">
 	08.08.2011</p>
 <p>
@@ -512,16 +512,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setupb7ee.html?id=F4A29&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup0d63.html?id=F4A29&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupfbd9.html?id=F4A29&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup3e63-2.html?id=F4A29&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup458a.html?id=F4A29&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupb7ee.html?id=F4A29&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup0d63.html?id=F4A29&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupfbd9.html?id=F4A29&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup3e63-2.html?id=F4A29&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup458a.html?id=F4A29&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -544,7 +544,7 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div> <div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Áèçíåñ, ìàðêåòèíã è ïðîäàæè&quot;</p> <ul><li><a href='F4AF2.html' title='Óïðàæíåíèå, ïîçâîëÿþùåå îïðåäåëèòü âàøó íèøó, óâèäåòü âàøåãî êëèåíòà è ñïîñîáû åãî ïðèâëå÷åíèÿ'>Âàø Áîá</a></li><li><a href='F4A88.html' title='Êàê òîëüêî Âû íà÷èíàåòå çàíèìàòüñÿ áèçíåñîì èëè ïðîäàæàìè, Âû ïîïàäàåòå â êëàññè÷åñêóþ äèëåììó Ëèäåðà: «Áûòü õîðîøèì ÷åëîâåêîì èëè ýôôåêòèâíî óïðàâëÿòü?».  Êàê âûéòè èç ýòîé äèëåììû è ñîâìåñòèòü è òî, è òî?'>Õîðîøèé äðóã - ïëîõîé äèðåêòîð. Êàê ñîâìåñòèòü è òî, è òî?</a></li><li><a href='F48AF.html' title='Ïðî îäèí èç ãëàâíûõ íàâûêîâ áèçíåñ-ìûøëåíèÿ, êîòîðûé íå òîëüêî äåëàåò íàøè äåéñòâèÿ íà ïîðÿäîê ýôôåêòèâíåå, íî è âûâîäèò íà íîâûé óðîâåíü çðåëîñòè.'>Õîòèòå ëó÷øèõ ðåçóëüòàòîâ? Ìûñëèòå ïðîåêòàìè!</a></li><li><a href='F4CE5.html' title=''>Ñàìûå ïîêóïàåìûå òåìû 2012<br/> (ñòàòèñòèêà ðàñïðîäàæè)</a></li><li><a href='F4C29.html' title='Ìîæíî âîñïðèíÿòü ýòó ñòàòüþ êàê øóòêó, à ìîæíî è êîå-÷òî ïîëåçíîå äëÿ ñåáÿ óçàòü ;) Íàïèøèòå, ïîæàëóéñòà, â êîììåíòàðèÿõ íàèáîëåå èíòåðåñíûå âàì òåìû (êàêîé òðåíèíã âû êóïèëè áû), èëè ïðèäóìàéòå ñâîþ òåìó. Òàêæå, ïðî÷èòàéòå ÷óæèå êîììåíòàðèè, è åñëè âàøà òåìà ñîâïàäàåò ñ ÷üåé-òî, òî ïîñòàâüòå êîììåíòàðèþ Ëàéê.'>Òåìû òðåíèíãîâ, ìîçãîâîé øòóðì</a></li></ul></div> 
+<!-- AddThis Button END --></div> <div class='relateditems'><p>Лучшие материалы раздела &quot;Бизнес, маркетинг и продажи&quot;</p> <ul><li><a href='F4AF2.html' title='Упражнение, позволяющее определить вашу нишу, увидеть вашего клиента и способы его привлечения'>Ваш Боб</a></li><li><a href='F4A88.html' title='Как только Вы начинаете заниматься бизнесом или продажами, Вы попадаете в классическую дилемму Лидера: «Быть хорошим человеком или эффективно управлять?».  Как выйти из этой дилеммы и совместить и то, и то?'>Хороший друг - плохой директор. Как совместить и то, и то?</a></li><li><a href='F48AF.html' title='Про один из главных навыков бизнес-мышления, который не только делает наши действия на порядок эффективнее, но и выводит на новый уровень зрелости.'>Хотите лучших результатов? Мыслите проектами!</a></li><li><a href='F4CE5.html' title=''>Самые покупаемые темы 2012<br/> (статистика распродажи)</a></li><li><a href='F4C29.html' title='Можно воспринять эту статью как шутку, а можно и кое-что полезное для себя узать ;) Напишите, пожалуйста, в комментариях наиболее интересные вам темы (какой тренинг вы купили бы), или придумайте свою тему. Также, прочитайте чужие комментарии, и если ваша тема совпадает с чьей-то, то поставьте комментарию Лайк.'>Темы тренингов, мозговой штурм</a></li></ul></div> 
 <script>
 var idcomments_acct = '17aaea12c8826f1a4adde6fd2173ce48';
 var idcomments_post_id = 'F4A29';
@@ -570,11 +570,11 @@ var idcomments_post_url = 'F4A29.html';
 		  fjs.parentNode.insertBefore(js, fjs);
 		}(document, 'script', 'facebook-jssdk'));</script>
 
-<h3>Êîììåíòàðèè Facebook</h3>
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A29" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -594,12 +594,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -623,8 +623,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -632,11 +632,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -695,7 +695,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -717,7 +717,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A2A.html
+++ b/F4A2A.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A2A by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:04:03 GMT -->
 <head>
-        <title>5 îøèáîê, "óáèâàþùèå" ïðîäàæè òðåíèíãîâ</title>
+        <title>5 ошибок, "убивающие" продажи тренингов</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="5 îøèáîê ïðè ïðîäàæå òðåíèíãîâ, íå ïîçâîëÿþùèå âûéòè íà íîâûé óðîâåíü" />
+        <meta name="description" content="5 ошибок при продаже тренингов, не позволяющие выйти на новый уровень" />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='11E0E292-F4297-CBD0453C.html'>Äëÿ ÍËÏåðîâ</a> </span> / 5 îøèáîê, "óáèâàþùèå" ïðîäàæè òðåíèíãîâ                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='11E0E292-F4297-CBD0453C.html'>Для НЛПеров</a> </span> / 5 ошибок, "убивающие" продажи тренингов                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,52 +399,52 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print65c7.html?id=F4A2A"><img src="images/printer.jpg"></a></div>
-                                    <h1>5 îøèáîê, "óáèâàþùèå" ïðîäàæè òðåíèíãîâ</h1>
+                                    <h1>5 ошибок, "убивающие" продажи тренингов</h1>
                                                                     <p>
                                         <p>
-	Ñóùåñòâóþò ïÿòü îñíîâíûõ îøèáîê, êîòîðûå &laquo;óáèâàþò&raquo; ïðîäàæè Âàøèõ òðåíèíãîâ. Â òî âðåìÿ êàê Âû ïðèëàãàåòå óñèëèÿ è òÿíåòåñü ââåðõ, ýòè êàìíè íå äàþò Âàì ïîäíÿòüñÿ âûøå. Èçáàâüòåñü îò ãðóçà è ïîëó÷èòå ëó÷øèé ðåçóëüòàò.</p>
+	Существуют пять основных ошибок, которые &laquo;убивают&raquo; продажи Ваших тренингов. В то время как Вы прилагаете усилия и тянетесь вверх, эти камни не дают Вам подняться выше. Избавьтесь от груза и получите лучший результат.</p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 16px;"><strong>Îòóñóòñòâèå ïðåäîïëàòû.</strong></span></p>
+	<span style="font-size: 16px;"><strong>Отусутствие предоплаты.</strong></span></p>
 <p>
-	Ïðè ïðåäîïëàòå êîíâåðñèÿ ñîñòàâëÿåò îò 70-75%. Íå íóæíî áðàòü 50- 40% ïðåäîïëàòû, âïîëíå äîñòàòî÷íî 10%. Åñëè Âàø òðåíèíã ñòîèò 10&nbsp;000, âîçüìèòå 1000 ðóáëåé. Íåáîëüøàÿ ïðåäîïëàòà áóäåò ñòèìóëîì ê äàëüíåéøèì äåéñòâèÿì.</p>
-<p>
-	&nbsp;</p>
-<p>
-	<span style="font-size: 16px;"><span style="font-weight: bold;">Î</span><strong>òñóòñòâèå ãàðàíòèé</strong>. </span></p>
-<p>
-	Î÷åíü ìíîãèå òðåíåðû íå õîòÿò äàâàòü ãàðàíòèè íà ñâîè òðåíèíãè, íå ñ÷èòàÿ èõ ïðîäóêòîì. Åñëè Âû äàåòå ãàðàíòèè, êîíâåðñèÿ îò ýòîãî ñòàíîâèòñÿ áîëüøå. Äàâàéòå ëþäÿì ãàðàíòèè, ýòî íå ïîäîðâåò Âàøè ïðîäàæè, à ëèøü èõ óñèëèò. ×åëîâåê ñïîêîåí, åñëè îí âèäèò ðåçóëüòàò, ëþäè ëîÿëüíû ê êà÷åñòâåííûì òðåíèíãàì.</p>
+	При предоплате конверсия составляет от 70-75%. Не нужно брать 50- 40% предоплаты, вполне достаточно 10%. Если Ваш тренинг стоит 10&nbsp;000, возьмите 1000 рублей. Небольшая предоплата будет стимулом к дальнейшим действиям.</p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 16px;"><strong>Íåâåðíî âûáðàííàÿ íèøà</strong>. </span></p>
+	<span style="font-size: 16px;"><span style="font-weight: bold;">О</span><strong>тсутствие гарантий</strong>. </span></p>
 <p>
-	È äàæå ïðè íàëè÷èè êà÷åñòâåííîãî òðåíèíãà åãî íåïðàâèëüíîå îïèñàíèå íå ïîçâîëèò ëþäÿì, êîòîðûì îí íóæåí, íàéòè åãî. Ñ òðåíèíãàìè âàæåí ìàðêåòèíã. Âàì ïðèäåòñÿ ñèëüíåå êðóòèòü ïåäàëè äëÿ Âàøèõ ïðîäàæ. Íî åñëè Âû ïðàâèëüíî âûáðàëè íèøó &ndash; Âû ïîëó÷èòå ñåðüåçíûé ïèàð è àóäèòîðèþ íà ãîä âïåðåä. Íèøà&ndash; ýòî 50% óñïåõà.</p>
-<p>
-	&nbsp;</p>
-<p>
-	<span style="font-size: 16px;"><strong>Ðàññûëêà ïî áàçå àíîíñîâ ñâîèõ ìåðîïðèÿòèé</strong>.</span></p>
-<p>
-	Åå ñîâåðøàþò âñå, è îíà î÷åíü ñèëüíî &laquo;óáèâàåò&raquo; Âàøè ïðîäàæè (îñîáåííî ýòî äåëàþ òðåíèíãîâûå öåíòðû, ó êîòîðûõ åñòü êëèåíòñêàÿ áàçà). Ýòè àíîíñû ÷èòàåò î÷åíü ìàëî ëþäåé. Íóæíî îòïðàâëÿòü â âàøó áàçó ïîëåçíûé êîíòåíò. Êîíòåíò íóæíî ñëàòü êàê&nbsp; íåáîëüøèå ñòàòüè, çàìåòêè, áàéêè èëè èñòîðèè.</p>
+	Очень многие тренеры не хотят давать гарантии на свои тренинги, не считая их продуктом. Если Вы даете гарантии, конверсия от этого становится больше. Давайте людям гарантии, это не подорвет Ваши продажи, а лишь их усилит. Человек спокоен, если он видит результат, люди лояльны к качественным тренингам.</p>
 <p>
 	&nbsp;</p>
 <p>
-	<span style="font-size: 16px;"><strong><span style="font-weight: bold;">À</span>íîíñû òðåíèíãîâ&nbsp; âìåñòî ïðîäàæ. </strong></span></p>
+	<span style="font-size: 16px;"><strong>Неверно выбранная ниша</strong>. </span></p>
 <p>
-	Íóæíî âìåñòî àíîíñîâ äåëàòü ïðîäàæè, ÷òîá Âû ñðàçó çíàëè, ñêîëüêî ëþäåé áóäåò ó âàñ íà òðåíèíãå. Êîãäà Âàì íåîáõîäèìî ñîáèðàòü áàçó ïîä íîâûé òðåíèíã, ñîáèðàéòå åå ïîä íèøó ñâîåé ëèíåéêè òðåíèíãîâ.</p>
+	И даже при наличии качественного тренинга его неправильное описание не позволит людям, которым он нужен, найти его. С тренингами важен маркетинг. Вам придется сильнее крутить педали для Ваших продаж. Но если Вы правильно выбрали нишу &ndash; Вы получите серьезный пиар и аудиторию на год вперед. Ниша&ndash; это 50% успеха.</p>
 <p>
 	&nbsp;</p>
 <p>
-	Èñïîëüçóéòå óäà÷íûå ñòðàòåãèè, ìîäåëèðóéòå óñïåøíûõ ëþäåé, Âû óâåëè÷èòå ñâîþ ïðèáûëü è èçáàâèòåñü îò îñíîâíûõ îøèáîê.</p>
+	<span style="font-size: 16px;"><strong>Рассылка по базе анонсов своих мероприятий</strong>.</span></p>
 <p>
-	p.s. Îá ýòîì ïîäðîáíî ÿ ðàññêàçàë íà <a href="indexd330.html?id=F4A15">áåïëàòíîì âåáèíàðå ïî ïðîäàæå ÍËÏ-òðåíèíãîâ</a>.</p>
+	Ее совершают все, и она очень сильно &laquo;убивает&raquo; Ваши продажи (особенно это делаю тренинговые центры, у которых есть клиентская база). Эти анонсы читает очень мало людей. Нужно отправлять в вашу базу полезный контент. Контент нужно слать как&nbsp; небольшие статьи, заметки, байки или истории.</p>
+<p>
+	&nbsp;</p>
+<p>
+	<span style="font-size: 16px;"><strong><span style="font-weight: bold;">А</span>нонсы тренингов&nbsp; вместо продаж. </strong></span></p>
+<p>
+	Нужно вместо анонсов делать продажи, чтоб Вы сразу знали, сколько людей будет у вас на тренинге. Когда Вам необходимо собирать базу под новый тренинг, собирайте ее под нишу своей линейки тренингов.</p>
+<p>
+	&nbsp;</p>
+<p>
+	Используйте удачные стратегии, моделируйте успешных людей, Вы увеличите свою прибыль и избавитесь от основных ошибок.</p>
+<p>
+	p.s. Об этом подробно я рассказал на <a href="indexd330.html?id=F4A15">беплатном вебинаре по продаже НЛП-тренингов</a>.</p>
 <p align="right">
-	Åãîð Áóëûãèí,</p>
+	Егор Булыгин,</p>
 <p align="right">
-	êîó÷ ïî ïðîäàæàì òðåíèíãîâ</p>
+	коуч по продажам тренингов</p>
 <p>
-	Åñëè Âû ñ÷èòàåòå ýòîò ìàòåðàë ïîëåçíûì, ïîäåëèòåñü ñ äðóãèìè!</p>
+	Если Вы считаете этот матерал полезным, поделитесь с другими!</p>
 <p>
 	<a name='vote'></a><script type='text/javascript'>
 function light(num){
@@ -468,16 +468,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup5516.html?id=F4A2A&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup5730.html?id=F4A2A&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup5c78.html?id=F4A2A&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup0d32.html?id=F4A2A&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupc2f5.html?id=F4A2A&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup5516.html?id=F4A2A&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup5730.html?id=F4A2A&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup5c78.html?id=F4A2A&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup0d32.html?id=F4A2A&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupc2f5.html?id=F4A2A&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -500,12 +500,12 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div> <div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Äëÿ ÍËÏåðîâ&quot;</p> <ul><li><a href='F4AF1.html' title=''>Ýòàïû ðàçâèòèÿ òðåíåðîâ</a></li><li><a href='F4AF4.html' title=''>Äëÿ ÷åãî íóæåí ìàðêåòèíã</a></li><li><a href='F4AF5.html' title='Â ýòîì âûïóñêå î òîì, êàê ïðàâèëüíî ñòðîèòü ñâîþ ìàðêåòèíãîâóþ ëèíåéêó è âçàèìîäåéñòâîâàòü ñ êëèåíòîì. '>Ìàðêåòèíãîâàÿ ëèíåéêà è ìåòîäèêà ñòóïåíåê</a></li><li><a href='F4A18.html' title='×òî íóæíî ñäåëàòü íà÷èíàþùåìó òðåíåðó, ÷òîáû ñîçäàòü âîñòðåáîâàííûé òðåíèíã.'>Äâà ïðàâèëà ëó÷øåãî òðåíèíãà</a></li><li><a href='F4AF3.html' title='×òî òàêîå "Ìàðêåòèíãîâûé êâàäðàíò"? Êàê è êîãäà èñïîëüçîâàòü ïðèåì "Èñòîðèè" èëè "Êà÷åëè"? Îá ýòîì â îäíîì èç êóñî÷êîâ "Òðåíèíãà íà ìèëëèîí".'>Ìàðêåòèíãîâûé êâàäðàíò</a></li></ul></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<!-- AddThis Button END --></div> <div class='relateditems'><p>Лучшие материалы раздела &quot;Для НЛПеров&quot;</p> <ul><li><a href='F4AF1.html' title=''>Этапы развития тренеров</a></li><li><a href='F4AF4.html' title=''>Для чего нужен маркетинг</a></li><li><a href='F4AF5.html' title='В этом выпуске о том, как правильно строить свою маркетинговую линейку и взаимодействовать с клиентом. '>Маркетинговая линейка и методика ступенек</a></li><li><a href='F4A18.html' title='Что нужно сделать начинающему тренеру, чтобы создать востребованный тренинг.'>Два правила лучшего тренинга</a></li><li><a href='F4AF3.html' title='Что такое "Маркетинговый квадрант"? Как и когда использовать прием "Истории" или "Качели"? Об этом в одном из кусочков "Тренинга на миллион".'>Маркетинговый квадрант</a></li></ul></div> 
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A2A" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -543,12 +543,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -572,8 +572,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -581,11 +581,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -644,7 +644,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -666,7 +666,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A2B.html
+++ b/F4A2B.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A2B by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:13:41 GMT -->
 <head>
-        <title>Ìîæåò ëè áóëêà ïðîäàâàòü?</title>
+        <title>Может ли булка продавать?</title>
         <meta name="robots" content="index,follow" />
         <meta name="description" content="" />
-        <meta name="keywords" content="Ïî÷åìó äëÿ ìàëîãî áèçíåñà òàê âàæíî èìåòü ïðàâèëüíþ ëèíåéêó ïðîäàæ, íàöåëåííóþ íà äîëãîñðî÷íûå ïåðñïåêòèâû?" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta name="keywords" content="Почему для малого бизнеса так важно иметь правильню линейку продаж, нацеленную на долгосрочные перспективы?" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='F48A6.html'>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</a> </span> / Ìîæåò ëè áóëêà ïðîäàâàòü?                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='F48A6.html'>Бизнес, маркетинг и продажи</a> </span> / Может ли булка продавать?                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,35 +399,35 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print8b1e.html?id=F4A2B"><img src="images/printer.jpg"></a></div>
-                                    <h1>Ìîæåò ëè áóëêà ïðîäàâàòü?</h1>
+                                    <h1>Может ли булка продавать?</h1>
                                                                     <p>
                                         <p>
-	Ñàìûå ýôôåêòèâíûå ðåøåíèÿ óæå äàâíî ïðèäóìàíû. Ñòîèò ëè èçîáðåòàòü âåëîñèïåä èëè ïðîñòî èñïîëüçîâàòü ýòè ôèøêè?&nbsp;<br />
+	Самые эффективные решения уже давно придуманы. Стоит ли изобретать велосипед или просто использовать эти фишки?&nbsp;<br />
 	<br />
-	<span style="font-size: 16px;"><strong>Áóëêà - íå ãëàâíîå</strong></span><br />
+	<span style="font-size: 16px;"><strong>Булка - не главное</strong></span><br />
 	<br />
-	Ìàêäîíàëäñ èìååò îòëè÷íóþ ñèñòåìó ïðîäàæ. Êàê Âû äóìàåòå, íà ÷åì îí çàðàáàòûâàåò?<br />
+	Макдоналдс имеет отличную систему продаж. Как Вы думаете, на чем он зарабатывает?<br />
 	<br />
-	Âêóñíàÿ, ñûòíàÿ, áîëüøàÿ áóëêà, êîòîðîé î÷åíü ëåãêî ïåðåêóñèòü è çà êîòîðîé ëþäè ïðèõîäÿò &ndash; ýòî õîðîøèé âàðèàíò.Íî êîãäà Âû ñúåäàåòå ýòîò ãàìáóðãåð, Âàì óæàñíî õî÷åòñÿ ïèòü è Âû ïîêóïàåòå âìåñòå ñ ãàìáóðãåðîì ÷àé, êîôå, ñîê. È â èòîãå Âàì ïðîäàþò áîëüøå, ÷åì Âû ôèçè÷åñêè ìîæåòå ñúåñòü.<br />
+	Вкусная, сытная, большая булка, которой очень легко перекусить и за которой люди приходят &ndash; это хороший вариант.Но когда Вы съедаете этот гамбургер, Вам ужасно хочется пить и Вы покупаете вместе с гамбургером чай, кофе, сок. И в итоге Вам продают больше, чем Вы физически можете съесть.<br />
 	<br />
-	Íà ãàìáóðãåðàõ â Ìàêäîíàëäñå î÷åíü íåáîëüøîé ïðîöåíò ïðèáûëè. Íî åñëè Âû ïîñìîòðèòå íà ñòîèìîñòü ãàìáóðãåðà èëè íà ñòîèìîñòü êîëû èëè êîôå, è ñðàâíèòå ñ ñåáåñòîèìîñòüþ ãàìáóðãåðà ñåáåñòîèìîñòü êîôå èëè êîëû, âû óâèäèòå, ÷òî ðåàëüíî õîðîøàÿ ìàðæà â 90% ïîëó÷àåòñÿ êàê ðàç íà íàïèòêàõ. È íàïèòêè ëþäè íåèçáåæíî áóäóò ïîêóïàòü âìåñòå ñ åäîé. È íà ýòîì êàê ðàç Ìàêäîíàëäñ çàðàáàòûâàåò.<br />
+	На гамбургерах в Макдоналдсе очень небольшой процент прибыли. Но если Вы посмотрите на стоимость гамбургера или на стоимость колы или кофе, и сравните с себестоимостью гамбургера себестоимость кофе или колы, вы увидите, что реально хорошая маржа в 90% получается как раз на напитках. И напитки люди неизбежно будут покупать вместе с едой. И на этом как раз Макдоналдс зарабатывает.<br />
 	<br />
-	<span style="font-size: 16px;"><strong>Ñòðîéòå ñèñòåìó</strong></span><br />
+	<span style="font-size: 16px;"><strong>Стройте систему</strong></span><br />
 	<br />
-	Â èäåàëå, Âàì íåîáõîäèìî ñäåëàòü òàê, ÷òîáû Âàøè êëèåíòû çàâèñåëè îò Âàñ ïî ñèñòåìå Ìàêäîíàëäñà. À ýòî çíà÷èò, Âàì íåîáõîäèìî èìåòü öåëóþ ëèíåéêó ïðîäóêòîâ.<br />
+	В идеале, Вам необходимо сделать так, чтобы Ваши клиенты зависели от Вас по системе Макдоналдса. А это значит, Вам необходимо иметь целую линейку продуктов.<br />
 	<br />
-	Â ëþáîé ìîìåíò Âû ìîæåòå ïðåäëîæèòü î÷åíü öåííûé ïðîäóêò è îí áóäåò î÷åíü äåøåâûé, Âû ìàêñèìàëüíî ëåãêî ïîëó÷àåòå êëèåíòà. À äðóãèå ïðîäóêòû áóäóò ñèëüíî íåîáõîäèìû, íå ïðîñòî î÷åíü öåííû, à íåîáõîäèìû. Ïðè ýòîì áóäóò èìåòü î÷åíü íèçêóþ ñåáåñòîèìîñòü è ìàêñèìàëüíóþ ñòîèìîñòü.</p>
+	В любой момент Вы можете предложить очень ценный продукт и он будет очень дешевый, Вы максимально легко получаете клиента. А другие продукты будут сильно необходимы, не просто очень ценны, а необходимы. При этом будут иметь очень низкую себестоимость и максимальную стоимость.</p>
 <p>
 	&nbsp;</p>
 <p>
-	<strong>p.s</strong>. 27 &ndash; 29 àâãóñòà ÿ ïðîâåäó <a href="index3f0c.html?id=money-IQ">æèâîé òðåíèíã &laquo;Äåíåæíûé èíòåëëåêò&raquo;</a>. ß ïîìîãó âíåäðèòü òåõíèêè è èñïîëüçîâàòü èõ ìàêñèìàëüíî êà÷åñòâåííî.</p>
+	<strong>p.s</strong>. 27 &ndash; 29 августа я проведу <a href="index3f0c.html?id=money-IQ">живой тренинг &laquo;Денежный интеллект&raquo;</a>. Я помогу внедрить техники и использовать их максимально качественно.</p>
 <p>
-	Åñëè âû óæå ïîíèìàåòå, ÷òî Âû áóäåòå äåëàòü, ñåðüåçíî íàìåðåíû çàíèìàòüñÿ áèçíåñîì è çàðàáîòàòü íåñêîëüêî òûñÿ÷ äîëëàðîâ, à òî è äåñÿòêè òûñÿ÷ äîëëàðîâ &ndash; âîò òîãäà ýòîò òðåíèíã äëÿ Âàñ ïîäõîäèò.</p>
+	Если вы уже понимаете, что Вы будете делать, серьезно намерены заниматься бизнесом и заработать несколько тысяч долларов, а то и десятки тысяч долларов &ndash; вот тогда этот тренинг для Вас подходит.</p>
 <p style="text-align: right;">
 	&nbsp;</p>
 <p style="text-align: right;">
-	ñ óâàæåíèåì,<br />
-	Åãîð Áóëûãèí</p>
+	с уважением,<br />
+	Егор Булыгин</p>
 <p>
 	<a name='vote'></a><script type='text/javascript'>
 function light(num){
@@ -451,16 +451,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup84b3.html?id=F4A2B&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup05d2.html?id=F4A2B&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup6bf2.html?id=F4A2B&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupe18d.html?id=F4A2B&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupb9f9.html?id=F4A2B&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup84b3.html?id=F4A2B&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup05d2.html?id=F4A2B&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup6bf2.html?id=F4A2B&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupe18d.html?id=F4A2B&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupb9f9.html?id=F4A2B&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -484,11 +484,11 @@ function voted(){
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
 <!-- AddThis Button END --></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A2B" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -526,12 +526,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -555,8 +555,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -564,11 +564,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -627,7 +627,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -649,7 +649,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A2C.html
+++ b/F4A2C.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A2C by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:20:07 GMT -->
 <head>
-        <title>7 èëè 8?</title>
+        <title>7 или 8?</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="3 ôóíäàìåíòàëüíûõ îñíîâû èíòóöèè" />
+        <meta name="description" content="3 фундаментальных основы интуции" />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='video.html'>Âèäåî</a> </span> / 7 èëè 8?                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='video.html'>Видео</a> </span> / 7 или 8?                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,7 +399,7 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print06bc.html?id=F4A2C"><img src="images/printer.jpg"></a></div>
-                                    <h1>7 èëè 8?</h1>
+                                    <h1>7 или 8?</h1>
                                                                     <p>
                                         <p style="text-align: center;">
 	<iframe allowfullscreen="" frameborder="0" height="390" src="http://www.youtube.com/embed/xiGlacyMPL0" width="640"></iframe></p>
@@ -426,16 +426,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup9d46.html?id=F4A2C&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupd99a.html?id=F4A2C&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup90be.html?id=F4A2C&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupde7c.html?id=F4A2C&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupb92c.html?id=F4A2C&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup9d46.html?id=F4A2C&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupd99a.html?id=F4A2C&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup90be.html?id=F4A2C&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupde7c.html?id=F4A2C&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupb92c.html?id=F4A2C&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -458,12 +458,12 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div><div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Âèäåî&quot;</p> <ul><li><a href='F47BA.html' title='Ïî÷åìó ëþäè ìàíèïóëèðóþò, êàê çàùèòèòüñÿ îò ýòîãî è ÷åì ìîòèâàöèÿ îòëè÷àåòñÿ îò ìàíèïóëÿöèè. Ôðàãìåíò ñ ïðåçåíòàöèè êíèãè "ÍËÏ êàê îíî åñòü".'>Ìàíèïóëÿöèÿ</a></li><li><a href='F48E0.html' title='×àñòü ïåðâàÿ: Ïîòîê ðóëèò! Íî âûáîð òû äîëæåí ñäåëàòü ñàì. Âèäåî óðîê â ðàìêàõ òåñò-äðàéâà ïðåäñòîÿùåãî òðåíèíãà.'>Êàê âûéòè çà ïðåäåëû âîçìîæíîãî? (1)</a></li><li><a href='F48E1.html' title='Óðîâíè æèçíè. Êàê âûéòè çà ãðàíèöû òîãî, ÷òî ìû ñ÷èòàåì âîçìîæíûì?'>Êàê âûéòè çà ïðåäåëû âîçìîæíîãî? (2)</a></li><li><a href='F4A3F.html' title='Êàê íóæíî èçìåíèòü ñâîå ìûøëåíèå, ÷òîáû âûéòè íà íîâûé óðîâåíü â áèçíåñå.'>Êàê èçáåæàòü êðèçèñà â áèçíåñå</a></li><li><a href='F47B5.html' title='Âèäåî ôðàãìåíò ïðåçåíòàöèè êíèãè "ÍËÏ êàê îíî åñòü. Ïðàêòèêà óñïåõà". Åãîð Áóëûãèí.'>Êàê íå "çàëèïàòü" â ÷óæèå ðîëè è îñòàâàòüñÿ ñîáîé?</a></li></ul></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<!-- AddThis Button END --></div><div class='relateditems'><p>Лучшие материалы раздела &quot;Видео&quot;</p> <ul><li><a href='F47BA.html' title='Почему люди манипулируют, как защититься от этого и чем мотивация отличается от манипуляции. Фрагмент с презентации книги "НЛП как оно есть".'>Манипуляция</a></li><li><a href='F48E0.html' title='Часть первая: Поток рулит! Но выбор ты должен сделать сам. Видео урок в рамках тест-драйва предстоящего тренинга.'>Как выйти за пределы возможного? (1)</a></li><li><a href='F48E1.html' title='Уровни жизни. Как выйти за границы того, что мы считаем возможным?'>Как выйти за пределы возможного? (2)</a></li><li><a href='F4A3F.html' title='Как нужно изменить свое мышление, чтобы выйти на новый уровень в бизнесе.'>Как избежать кризиса в бизнесе</a></li><li><a href='F47B5.html' title='Видео фрагмент презентации книги "НЛП как оно есть. Практика успеха". Егор Булыгин.'>Как не "залипать" в чужие роли и оставаться собой?</a></li></ul></div> 
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A2C" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -501,12 +501,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -530,8 +530,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -539,11 +539,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -602,7 +602,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -624,7 +624,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A2D.html
+++ b/F4A2D.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A2D by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:13:47 GMT -->
 <head>
-        <title>4 òèïà êëèåíòîâ â Âàøåé íèøå</title>
+        <title>4 типа клиентов в Вашей нише</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="Êàê óäîâëåòâîðèòü ïîòðåáíîñòè ðàçíûõ êëèåíòîâ â îäíîé öåëåâîé íèøå?" />
+        <meta name="description" content="Как удовлетворить потребности разных клиентов в одной целевой нише?" />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='F48A6.html'>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</a> </span> / 4 òèïà êëèåíòîâ â Âàøåé íèøå                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='F48A6.html'>Бизнес, маркетинг и продажи</a> </span> / 4 типа клиентов в Вашей нише                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,40 +399,40 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="printabc1.html?id=F4A2D"><img src="images/printer.jpg"></a></div>
-                                    <h1>4 òèïà êëèåíòîâ â Âàøåé íèøå</h1>
+                                    <h1>4 типа клиентов в Вашей нише</h1>
                                                                     <p>
                                         <h3>
-	Â íèøå åñòü âñ¸... èëè âñå</h3>
+	В нише есть всё... или все</h3>
 <p>
 	&nbsp;</p>
 <p>
-	Ñåêðåò ëè â òîì, ÷òî áëàãîäàðÿ ïðàâèëüíî âûáðàííîé íèøå âëàäåëåö áèçíåñà ïîëó÷àåò õîðîøóþ ïðèáûëü? Äàâíî óæå íåò, åñëè çíàåòå, êàê ýòó íèøó íàéòè. Áåñïëàòíàÿ ìåòîäè÷êà ïî îïðåäåëåíèþ íèøè -<a href="indexf0a1.html?id=niching">http://nlping.ru/?id=niching</a>. Â Âàøåé íèøå ëþäè íåîäíîðîäíû, è ó êàæäîãî åñòü îïðåäåëåííûé èíòåðåñ ê Âàøåé óñëóãå.</p>
+	Секрет ли в том, что благодаря правильно выбранной нише владелец бизнеса получает хорошую прибыль? Давно уже нет, если знаете, как эту нишу найти. Бесплатная методичка по определению ниши -<a href="indexf0a1.html?id=niching">http://nlping.ru/?id=niching</a>. В Вашей нише люди неоднородны, и у каждого есть определенный интерес к Вашей услуге.</p>
 <p>
-	ß äëÿ ñåáÿ îïðåäåëèë 4 òèïà êëèåíòîâ â íèøå &ndash; åñòü òå, êòî ïðèõîäèò íàõàëÿâó, åñòü òå, êòî èùåò ñàìîå äåøåâîå, åñòü òå, êòî èùåò îïòèìàëüíî öåíó/êà÷åñòâî, è åñòü òå, êòî èùåò ïðåìèóì-ïðîäóêò. Ó êàæäîé èç ýòèõ àóäèòîðèé ñâîÿ ìîòèâàöèÿ è ñâîé ïðîäóêò.</p>
+	Я для себя определил 4 типа клиентов в нише &ndash; есть те, кто приходит нахаляву, есть те, кто ищет самое дешевое, есть те, кто ищет оптимально цену/качество, и есть те, кто ищет премиум-продукт. У каждой из этих аудиторий своя мотивация и свой продукт.</p>
 <p>
-	Ðàáîòàòü Âàì íåîáõîäèìî ñî âñåìè êëèåíòàìè &ndash; íåêîòîðûå ìîãóò ïåðåõîäèòü èç îäíîãî ñîñòîÿíèÿ â äðóãîå. È êîíå÷íî, ó Âàñ íàãîòîâå öåëàÿ ëèíåéêà óñëóã äëÿ ðàçíûõ êàòåãîðèé êëèåíòîâ.</p>
+	Работать Вам необходимо со всеми клиентами &ndash; некоторые могут переходить из одного состояния в другое. И конечно, у Вас наготове целая линейка услуг для разных категорий клиентов.</p>
 <p>
 	&nbsp;</p>
 <h3>
-	<strong>Cåðâèñ íà 1000%</strong></h3>
+	<strong>Cервис на 1000%</strong></h3>
 <p>
 	&nbsp;</p>
 <p>
-	Íî VIP-cåãìåíò, VIP-ñåðâèñ ýòî òî, íà ÷åì Âû áóäåòå çàðàáàòûâàòü áîëüøå âñåãî. Ýòè êëèåíòû ïîêóïàþò ñåáå âðåìÿ, çàâåäîìî ëó÷øåå îòíîøåíèå è îòñóòñòâèå ãîëîâíîé áîëè. Èõ ïîçèöèÿ íåïîêîëåáèìà &ndash; çà áîëüøèå äåíüãè îíè ïîêóïàþò äëÿ ñåáÿ ñàìûé êà÷åñòâåííûé ïðîäóêò.</p>
+	Но VIP-cегмент, VIP-сервис это то, на чем Вы будете зарабатывать больше всего. Эти клиенты покупают себе время, заведомо лучшее отношение и отсутствие головной боли. Их позиция непоколебима &ndash; за большие деньги они покупают для себя самый качественный продукт.</p>
 <p>
-	Êîãäà ÿ ëå÷ó ðåéñîì Ìîñêâà-Êèåâ, êàê ÿ âûáèðàþ ñåáå ìåñòî? Äà, ÿ ñìîòðþ âûãîäíûå ïðåäëîæåíèÿ îò ðàçíûõ êîìïàíèé &ndash; ìîå ìåñòî â ñåãìåíòå òåõ, êòî èùåò ñàìîå äåøåâîå, è ìíå íå íóæåí èíòåðíåò è ïëååð. Äåøåâî è ñåðäèòî.</p>
+	Когда я лечу рейсом Москва-Киев, как я выбираю себе место? Да, я смотрю выгодные предложения от разных компаний &ndash; мое место в сегменте тех, кто ищет самое дешевое, и мне не нужен интернет и плеер. Дешево и сердито.</p>
 <p>
-	Íî âîò ÿ ëå÷ó ðåéñîì Ìîñêâà-Áàíãêîê. 12 ÷àñîâ â êðåñëå ìíå óæå õî÷åòñÿ ïðîâåñòè íå òîëüêî ñ êîìôîðòîì, íî ñ îòëè÷íûì êîìôîðòîì &ndash; èíòåðíåò äëÿ ðàáîòû, èëè óäîáíîå îòêèäûâàþùååñÿ êðåñëî, ãäå ìîæíî îòëè÷íî âçäðåìíóòü. Ýêîíîì-êëàññ òàêæå ðÿäîì, çà ïåðåãîðîäêîé, òî÷íî òàêæå ëåòèò â Áàíãêîê, íî ÿ ïîêóïàþ ñåáå ñïîêîéñòâèå, êîìôîðò è îáñëóæèâàíèå, ìîå ìåñòî â äðóãîì ñåãìåíòå.</p>
-<p>
-	&nbsp;</p>
-<p>
-	Èìåéòå â âèäó &ndash; íà VIP-ñåðâèñå ìîæíî çàðàáîòàòü áîëüøå îñòàëüíûõ ñåãìåíòîâ, íî ó Âàñ îáÿçàòåëüíî äîëæåí áûòü ïðîäóêò äëÿ ëþáîãî èç 4 òèïîâ êëèåíòîâ â Âàøåé íèøå.</p>
+	Но вот я лечу рейсом Москва-Бангкок. 12 часов в кресле мне уже хочется провести не только с комфортом, но с отличным комфортом &ndash; интернет для работы, или удобное откидывающееся кресло, где можно отлично вздремнуть. Эконом-класс также рядом, за перегородкой, точно также летит в Бангкок, но я покупаю себе спокойствие, комфорт и обслуживание, мое место в другом сегменте.</p>
 <p>
 	&nbsp;</p>
 <p>
-	P.S. À íà êàêîé ñåãìåíò ñåé÷àñ ðàññ÷èòàíî áîëüøèíñòâî óñëóã â Âàøåé ëèíåéêå?</p>
+	Имейте в виду &ndash; на VIP-сервисе можно заработать больше остальных сегментов, но у Вас обязательно должен быть продукт для любого из 4 типов клиентов в Вашей нише.</p>
+<p>
+	&nbsp;</p>
+<p>
+	P.S. А на какой сегмент сейчас рассчитано большинство услуг в Вашей линейке?</p>
 <p style="text-align: right;">
-	Åãîð Áóëûãèí</p>
+	Егор Булыгин</p>
 <p style="text-align: right;">
 	17.08.2011</p>
 <p style="text-align: right;">
@@ -460,16 +460,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup3d2a.html?id=F4A2D&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupaabb.html?id=F4A2D&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupf9fa.html?id=F4A2D&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup4833.html?id=F4A2D&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupbfea.html?id=F4A2D&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup3d2a.html?id=F4A2D&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupaabb.html?id=F4A2D&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupf9fa.html?id=F4A2D&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup4833.html?id=F4A2D&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupbfea.html?id=F4A2D&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -492,12 +492,12 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div> <div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Áèçíåñ, ìàðêåòèíã è ïðîäàæè&quot;</p> <ul><li><a href='F4AF2.html' title='Óïðàæíåíèå, ïîçâîëÿþùåå îïðåäåëèòü âàøó íèøó, óâèäåòü âàøåãî êëèåíòà è ñïîñîáû åãî ïðèâëå÷åíèÿ'>Âàø Áîá</a></li><li><a href='F4A88.html' title='Êàê òîëüêî Âû íà÷èíàåòå çàíèìàòüñÿ áèçíåñîì èëè ïðîäàæàìè, Âû ïîïàäàåòå â êëàññè÷åñêóþ äèëåììó Ëèäåðà: «Áûòü õîðîøèì ÷åëîâåêîì èëè ýôôåêòèâíî óïðàâëÿòü?».  Êàê âûéòè èç ýòîé äèëåììû è ñîâìåñòèòü è òî, è òî?'>Õîðîøèé äðóã - ïëîõîé äèðåêòîð. Êàê ñîâìåñòèòü è òî, è òî?</a></li><li><a href='F48AF.html' title='Ïðî îäèí èç ãëàâíûõ íàâûêîâ áèçíåñ-ìûøëåíèÿ, êîòîðûé íå òîëüêî äåëàåò íàøè äåéñòâèÿ íà ïîðÿäîê ýôôåêòèâíåå, íî è âûâîäèò íà íîâûé óðîâåíü çðåëîñòè.'>Õîòèòå ëó÷øèõ ðåçóëüòàòîâ? Ìûñëèòå ïðîåêòàìè!</a></li><li><a href='F4CE5.html' title=''>Ñàìûå ïîêóïàåìûå òåìû 2012<br/> (ñòàòèñòèêà ðàñïðîäàæè)</a></li><li><a href='F4C29.html' title='Ìîæíî âîñïðèíÿòü ýòó ñòàòüþ êàê øóòêó, à ìîæíî è êîå-÷òî ïîëåçíîå äëÿ ñåáÿ óçàòü ;) Íàïèøèòå, ïîæàëóéñòà, â êîììåíòàðèÿõ íàèáîëåå èíòåðåñíûå âàì òåìû (êàêîé òðåíèíã âû êóïèëè áû), èëè ïðèäóìàéòå ñâîþ òåìó. Òàêæå, ïðî÷èòàéòå ÷óæèå êîììåíòàðèè, è åñëè âàøà òåìà ñîâïàäàåò ñ ÷üåé-òî, òî ïîñòàâüòå êîììåíòàðèþ Ëàéê.'>Òåìû òðåíèíãîâ, ìîçãîâîé øòóðì</a></li></ul></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<!-- AddThis Button END --></div> <div class='relateditems'><p>Лучшие материалы раздела &quot;Бизнес, маркетинг и продажи&quot;</p> <ul><li><a href='F4AF2.html' title='Упражнение, позволяющее определить вашу нишу, увидеть вашего клиента и способы его привлечения'>Ваш Боб</a></li><li><a href='F4A88.html' title='Как только Вы начинаете заниматься бизнесом или продажами, Вы попадаете в классическую дилемму Лидера: «Быть хорошим человеком или эффективно управлять?».  Как выйти из этой дилеммы и совместить и то, и то?'>Хороший друг - плохой директор. Как совместить и то, и то?</a></li><li><a href='F48AF.html' title='Про один из главных навыков бизнес-мышления, который не только делает наши действия на порядок эффективнее, но и выводит на новый уровень зрелости.'>Хотите лучших результатов? Мыслите проектами!</a></li><li><a href='F4CE5.html' title=''>Самые покупаемые темы 2012<br/> (статистика распродажи)</a></li><li><a href='F4C29.html' title='Можно воспринять эту статью как шутку, а можно и кое-что полезное для себя узать ;) Напишите, пожалуйста, в комментариях наиболее интересные вам темы (какой тренинг вы купили бы), или придумайте свою тему. Также, прочитайте чужие комментарии, и если ваша тема совпадает с чьей-то, то поставьте комментарию Лайк.'>Темы тренингов, мозговой штурм</a></li></ul></div> 
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A2D" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -535,12 +535,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -564,8 +564,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -573,11 +573,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -636,7 +636,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -658,7 +658,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A2F.html
+++ b/F4A2F.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A2F by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:16:49 GMT -->
 <head>
-        <title>Êàê áðàìèíû ïîäâèíóëè êøàòðèåâ</title>
+        <title>Как брамины подвинули кшатриев</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="Òèïî ïðèò÷à ;)" />
+        <meta name="description" content="Типо притча ;)" />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='600117C7-F45F0-9F94D6EA.html'>Áàéêè è ïðèò÷è</a> </span> / Êàê áðàìèíû ïîäâèíóëè êøàòðèåâ                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='600117C7-F45F0-9F94D6EA.html'>Байки и притчи</a> </span> / Как брамины подвинули кшатриев                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,28 +399,28 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print0c51.html?id=F4A2F"><img src="images/printer.jpg"></a></div>
-                                    <h1>Êàê áðàìèíû ïîäâèíóëè êøàòðèåâ</h1>
+                                    <h1>Как брамины подвинули кшатриев</h1>
                                                                     <p>
                                         <p>
 	&nbsp;</p>
 <p>
-	Õîäÿò ñëóõè, ÷òî äåëî áûëî òàê. Èçíà÷àëüíî â Èíäèè áûë 3 êàñòû.&nbsp; Øóäðû - ïðîñòûå ðàáî÷èå ëþäè. Âàéøüè&nbsp; - òîðãîâöû, ñàïîæíèêè, ïîðòíûå è ïðî÷èå ìàñòåðà íà âñå ðóêè (èíäèâèäóàëüíûå &nbsp;ïðåäïðèíèìàòåëè).&nbsp; Êøàòðèè &ndash; ãåíåðàëû, öàðè è ìåñòíûå ïðåçèäåíòû. À áðàìèíîâ íå áûëî.</p>
+	Ходят слухи, что дело было так. Изначально в Индии был 3 касты.&nbsp; Шудры - простые рабочие люди. Вайшьи&nbsp; - торговцы, сапожники, портные и прочие мастера на все руки (индивидуальные &nbsp;предприниматели).&nbsp; Кшатрии &ndash; генералы, цари и местные президенты. А браминов не было.</p>
 <p>
-	Â îäèí ïðåêðàñíûé ìîìåíò ïðèøëè î÷åíü óìíûå è î÷åíü ìóäðûå ëþäè, êîòîðûå, ïî ñëóõàì, óìåëè îáùàòüñÿ ñ áîãàìè, âèäåòü áóäóùåå, è âîîáùå çíàëè êàê óñòðîåí ìèð. Åñòåñòâåííî, êøàòðèÿì òàêèå ëþäè íóæíû áûëè â ñîâåòíèêè, ÷òîáû âåñòè äåëà ëåãêî è îïåðàòèâíî, è ìåíüøå êîñèòü íàðîäó â ñëó÷àå ìàñøòàáíûõ ðàçáîðîê íà êóðóêøåòàõ . Íó è îíè ñ íèìè çàïàðòíåðèëèñü.</p>
+	В один прекрасный момент пришли очень умные и очень мудрые люди, которые, по слухам, умели общаться с богами, видеть будущее, и вообще знали как устроен мир. Естественно, кшатриям такие люди нужны были в советники, чтобы вести дела легко и оперативно, и меньше косить народу в случае масштабных разборок на курукшетах . Ну и они с ними запартнерились.</p>
 <p>
-	Æèëè îíè òàê äîëãî è ñ÷àñòëèâî, è áðàìèíû íå æàäíè÷àëè, âûäàâàëè èì âñþ èíôîðìàöèþ, êîòîðóþ çíàëè, ÷èñòîñåðäå÷íî è ñ îòêðûòîé äóøîé. À çíàíèÿ, êàê èçâåñòíî, ñèëà. È â êàêîé-òî ìîìåíò êøàòðèè çàìåòèëè, ÷òî âñå ÷òî îíè äåëàþò, ïðîäèêòîâàíî áðàìèíàìè è äàâíûì-äàâíî óæå èäåò ïî ñèñòåìå, èìè æå ñîçäàííîé. Èñïóãàëèñü êøàòðèè çà âëàñòü ñâîþ, è ñêàçàëè îá ýòîì áðàìèíàì. Áðàìèíû, áóäó÷è ìóäðûìè, ñïîðèò ñ íèì íå ñòàëè, îòâåòèëè, ìî ë, íåò âîïðîñîâ, ìîæåò âàñ áîëüøå íå êîíñóëüòèðîâàòü. Òîãäà êøàòðèè ñåëè, ïîäâåëè áàëàíñ è ïîíÿëè, ÷òî òåðÿòü òàêèõ êîíñóëüòàíòîâ èì îïðåäåëåííî íå ðåçîí. Äåëà çà ïîñëåäíèå ãîäû ïîøëè â ãîðó, ñûòûõ ñòàëî áîëüøå, íàðîä ñòàë êóëüòóðíåå, è â îáùåì-òî âñå áûëî õîðîøî. Íó è çàêëþ÷èëè îíè ñ íèìè äîãîâîð, ïî êîòîðîìó âñÿ âëàñòü îñòàâàëàñü çà êøàòðèÿìè, à áðàìèíû ïðîñòî ïîëó÷àþò ñâîè äåíüãè.</p>
+	Жили они так долго и счастливо, и брамины не жадничали, выдавали им всю информацию, которую знали, чистосердечно и с открытой душой. А знания, как известно, сила. И в какой-то момент кшатрии заметили, что все что они делают, продиктовано браминами и давным-давно уже идет по системе, ими же созданной. Испугались кшатрии за власть свою, и сказали об этом браминам. Брамины, будучи мудрыми, спорит с ним не стали, ответили, мо л, нет вопросов, может вас больше не консультировать. Тогда кшатрии сели, подвели баланс и поняли, что терять таких консультантов им определенно не резон. Дела за последние годы пошли в гору, сытых стало больше, народ стал культурнее, и в общем-то все было хорошо. Ну и заключили они с ними договор, по которому вся власть оставалась за кшатриями, а брамины просто получают свои деньги.</p>
 <p>
-	Òàê êàê çíàíèå âñå òàêè äåéñòâèòåëüíî ñèëà, è áîëåå ÷åì áðàìèíû èìè íèêòî íå âëàäåë, äèâèäåíäû áðàìèíîâ ñèëüíî ïîäðîñëè, ïîïóëÿðíîñòü è ïî÷åò èõ óâåëè÷èëñÿ, è íàðîä ñòàë óâàæàòü èõ êàê æðåöîâ è âîîáùå ãóðó íà âñþ ãîëîâó. Íó è íå âûäåëèòü êàñòó äëÿ òàêèõ äîñòîéíûõ ëþäåé áûëî áû ïðîñòî íåóâàæåíèåì. &nbsp;Åñòåñòâåííûì îáðàçîì áðàìèíû îêàçàëèñü íàâåðõó.</p>
+	Так как знание все таки действительно сила, и более чем брамины ими никто не владел, дивиденды браминов сильно подросли, популярность и почет их увеличился, и народ стал уважать их как жрецов и вообще гуру на всю голову. Ну и не выделить касту для таких достойных людей было бы просто неуважением. &nbsp;Естественным образом брамины оказались наверху.</p>
 <p>
-	Ìîðàëü ýòîé èñòîðèè î÷åâèäíà, õîòÿ ïî íàøèì äàííûì, ýòî âñåãî ëèøü ñëóõè. Íà ñàìîì äåëå íèêòî íå çíàåò, êàê áûëî íà ñàìîì äåëå, êðîìå ñàìèõ áðàìèíîâ. Íî îíè îñîáî è íå îòðèöàþò ýòó âåðñèþ&hellip; ;)</p>
+	Мораль этой истории очевидна, хотя по нашим данным, это всего лишь слухи. На самом деле никто не знает, как было на самом деле, кроме самих браминов. Но они особо и не отрицают эту версию&hellip; ;)</p>
 <p>
 	&nbsp;</p>
 <p>
-	P.S. çàãàäî÷íûì îáðàçîì 4 èíäèéñêèõ êàñòû ñîâïàäàþò ñ 4 êâàäðàíòàìè Êèéîñàêè, 4 àðõåòèïàìè. Íà ïåðåñå÷åíèè&nbsp; ýòèõ ñèñòåì ìû ìîæåì óâèäåòü èíòåðåñíûå äåòàëè, ãîâîðÿùèå íàì, êàê ìîæíî ïðîäâèíóòüñÿ ïî ýòîìó ïóòè ââåðõ. Îá ýòîì ÿ ðàññêàæó ñåãîäíÿ, íà ìàñòåð-êëàññå <a href="index5585.html?id=F4A17">&laquo;Äåíåæíûé èíòåëëåêò - 4Q&raquo;.</a></p>
+	P.S. загадочным образом 4 индийских касты совпадают с 4 квадрантами Кийосаки, 4 архетипами. На пересечении&nbsp; этих систем мы можем увидеть интересные детали, говорящие нам, как можно продвинуться по этому пути вверх. Об этом я расскажу сегодня, на мастер-классе <a href="index5585.html?id=F4A17">&laquo;Денежный интеллект - 4Q&raquo;.</a></p>
 <p>
 	&nbsp;</p>
 <p style="text-align: right;">
-	<span class="service">Åãîð Áóëûãèí</span></p>
+	<span class="service">Егор Булыгин</span></p>
 <p style="text-align: right;">
 	24.08.2011</p>
 <p style="text-align: center;">
@@ -446,16 +446,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup913b.html?id=F4A2F&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup863b.html?id=F4A2F&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup8866.html?id=F4A2F&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupb379.html?id=F4A2F&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupd5a5.html?id=F4A2F&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup913b.html?id=F4A2F&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup863b.html?id=F4A2F&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup8866.html?id=F4A2F&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupb379.html?id=F4A2F&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupd5a5.html?id=F4A2F&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -478,12 +478,12 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div><div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Áàéêè è ïðèò÷è&quot;</p> <ul><li><a href='11EFAB56-F4620-8C197C8C.html' title='ÍËÏåðñêàÿ áàéêà.'>Ñàìàÿ âêóñíàÿ êîíôåòà</a></li><li><a href='F47A4.html' title='Ñêàçêà äëÿ âçðîñëûõ ïðî íè÷åãî-íå-íåäåëàíèå è ñìûñë.'>Ïðèò÷à "Ãîâîðÿùàÿ ðûáà"</a></li><li><a href='F479F.html' title='Ìíîãèå èç íàñ õîòÿò íà÷àòü ÷òî-òî íîâîå, íî íå ìíîãèå ýòî äåëàþò. Ïî÷åìó? Ïîòîìó ÷òî ìû ïðèâûêëè ê òîìó ÷òî èìååì, êàêèì áû îíî íè áûëî. È ïðè ìûñëè îá èçìåíåíèÿõ ó ìíîãèõ èç íàñ ïîÿâëÿåòñÿ ñòðàõ... '>Ïðèâû÷êè, ñòðàõè è óñïåõ</a></li><li><a href='F471C.html' title='Ïðèò÷à îò Íèëà Äîíàëüäà Óîëøà ïðî òî, êàê âàæíî ïîìíèòü, êòî ìû...'>Ìàëåíüêàÿ äóøà è ñîëíöå</a></li><li><a href='8DBBC4B9-F45F5-CE624629.html' title='Ïðèò÷à èç ñáîðíèêà 101 èñòîðèÿ äçåí.'>Õîðîøåå è ïëîõîå</a></li></ul></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<!-- AddThis Button END --></div><div class='relateditems'><p>Лучшие материалы раздела &quot;Байки и притчи&quot;</p> <ul><li><a href='11EFAB56-F4620-8C197C8C.html' title='НЛПерская байка.'>Самая вкусная конфета</a></li><li><a href='F47A4.html' title='Сказка для взрослых про ничего-не-неделание и смысл.'>Притча "Говорящая рыба"</a></li><li><a href='F479F.html' title='Многие из нас хотят начать что-то новое, но не многие это делают. Почему? Потому что мы привыкли к тому что имеем, каким бы оно ни было. И при мысли об изменениях у многих из нас появляется страх... '>Привычки, страхи и успех</a></li><li><a href='F471C.html' title='Притча от Нила Дональда Уолша про то, как важно помнить, кто мы...'>Маленькая душа и солнце</a></li><li><a href='8DBBC4B9-F45F5-CE624629.html' title='Притча из сборника 101 история дзен.'>Хорошее и плохое</a></li></ul></div> 
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A2F" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -521,12 +521,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -550,8 +550,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -559,11 +559,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -622,7 +622,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -644,7 +644,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A3F.html
+++ b/F4A3F.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A3F by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:20:13 GMT -->
 <head>
-        <title>Êàê èçáåæàòü êðèçèñà â áèçíåñå</title>
+        <title>Как избежать кризиса в бизнесе</title>
         <meta name="robots" content="index,follow" />
-        <meta name="description" content="Êàê íóæíî èçìåíèòü ñâîå ìûøëåíèå, ÷òîáû âûéòè íà íîâûé óðîâåíü â áèçíåñå." />
+        <meta name="description" content="Как нужно изменить свое мышление, чтобы выйти на новый уровень в бизнесе." />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='video.html'>Âèäåî</a> </span> / Êàê èçáåæàòü êðèçèñà â áèçíåñå                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='video.html'>Видео</a> </span> / Как избежать кризиса в бизнесе                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,12 +399,12 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="printc62a.html?id=F4A3F"><img src="images/printer.jpg"></a></div>
-                                    <h1>Êàê èçáåæàòü êðèçèñà â áèçíåñå</h1>
+                                    <h1>Как избежать кризиса в бизнесе</h1>
                                                                     <p>
                                         <p>
-	<span style="font-size: 16px;"><strong>Êàê íóæíî èçìåíèòü ñâîå ìûøëåíèå, ÷òîáû âûéòè íà íîâûé óðîâåíü â áèçíåñå.</strong></span></p>
+	<span style="font-size: 16px;"><strong>Как нужно изменить свое мышление, чтобы выйти на новый уровень в бизнесе.</strong></span></p>
 <p>
-	Ïðîìî-âèäåî ñ ìàñòåð-êëàññà Äåíåæíûé èíòåëëåêò-4Q&quot;</p>
+	Промо-видео с мастер-класса Денежный интеллект-4Q&quot;</p>
 <p>
 	&nbsp;</p>
 <p style="text-align: center;">
@@ -434,16 +434,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup9047.html?id=F4A3F&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup3627.html?id=F4A3F&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupefb8.html?id=F4A3F&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup0398.html?id=F4A3F&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup99c7.html?id=F4A3F&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup9047.html?id=F4A3F&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup3627.html?id=F4A3F&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupefb8.html?id=F4A3F&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup0398.html?id=F4A3F&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup99c7.html?id=F4A3F&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -466,12 +466,12 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div><div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Âèäåî&quot;</p> <ul><li><a href='F47BA.html' title='Ïî÷åìó ëþäè ìàíèïóëèðóþò, êàê çàùèòèòüñÿ îò ýòîãî è ÷åì ìîòèâàöèÿ îòëè÷àåòñÿ îò ìàíèïóëÿöèè. Ôðàãìåíò ñ ïðåçåíòàöèè êíèãè "ÍËÏ êàê îíî åñòü".'>Ìàíèïóëÿöèÿ</a></li><li><a href='F48E0.html' title='×àñòü ïåðâàÿ: Ïîòîê ðóëèò! Íî âûáîð òû äîëæåí ñäåëàòü ñàì. Âèäåî óðîê â ðàìêàõ òåñò-äðàéâà ïðåäñòîÿùåãî òðåíèíãà.'>Êàê âûéòè çà ïðåäåëû âîçìîæíîãî? (1)</a></li><li><a href='F48E1.html' title='Óðîâíè æèçíè. Êàê âûéòè çà ãðàíèöû òîãî, ÷òî ìû ñ÷èòàåì âîçìîæíûì?'>Êàê âûéòè çà ïðåäåëû âîçìîæíîãî? (2)</a></li><li><a href='F4A2C.html' title='3 ôóíäàìåíòàëüíûõ îñíîâû èíòóöèè'>7 èëè 8?</a></li><li><a href='F47B5.html' title='Âèäåî ôðàãìåíò ïðåçåíòàöèè êíèãè "ÍËÏ êàê îíî åñòü. Ïðàêòèêà óñïåõà". Åãîð Áóëûãèí.'>Êàê íå "çàëèïàòü" â ÷óæèå ðîëè è îñòàâàòüñÿ ñîáîé?</a></li></ul></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<!-- AddThis Button END --></div><div class='relateditems'><p>Лучшие материалы раздела &quot;Видео&quot;</p> <ul><li><a href='F47BA.html' title='Почему люди манипулируют, как защититься от этого и чем мотивация отличается от манипуляции. Фрагмент с презентации книги "НЛП как оно есть".'>Манипуляция</a></li><li><a href='F48E0.html' title='Часть первая: Поток рулит! Но выбор ты должен сделать сам. Видео урок в рамках тест-драйва предстоящего тренинга.'>Как выйти за пределы возможного? (1)</a></li><li><a href='F48E1.html' title='Уровни жизни. Как выйти за границы того, что мы считаем возможным?'>Как выйти за пределы возможного? (2)</a></li><li><a href='F4A2C.html' title='3 фундаментальных основы интуции'>7 или 8?</a></li><li><a href='F47B5.html' title='Видео фрагмент презентации книги "НЛП как оно есть. Практика успеха". Егор Булыгин.'>Как не "залипать" в чужие роли и оставаться собой?</a></li></ul></div> 
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A3F" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -509,12 +509,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -538,8 +538,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -547,11 +547,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -610,7 +610,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -632,7 +632,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A40.html
+++ b/F4A40.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A40 by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 13:20:19 GMT -->
 <head>
-        <title>Ðîñò êâàíòîâûì ñêà÷êîì</title>
+        <title>Рост квантовым скачком</title>
         <meta name="robots" content="index,follow" />
         <meta name="description" content="" />
-        <meta name="keywords" content="Êàê èçìåíèòü ñâîå ìûøëåíèå è âûéòè íà íîâûé óðîâåíü ðàçâèòèÿ áîëüøèì ðûâêîì" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta name="keywords" content="Как изменить свое мышление и выйти на новый уровень развития большим рывком" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='32347D7E-F4267-B9D62464.html'>Ñòàòüè è ìàòåðèàëû</a>  / <a href='video.html'>Âèäåî</a> </span> / Ðîñò êâàíòîâûì ñêà÷êîì                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='32347D7E-F4267-B9D62464.html'>Статьи и материалы</a>  / <a href='video.html'>Видео</a> </span> / Рост квантовым скачком                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,12 +399,12 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="print3661.html?id=F4A40"><img src="images/printer.jpg"></a></div>
-                                    <h1>Ðîñò êâàíòîâûì ñêà÷êîì</h1>
+                                    <h1>Рост квантовым скачком</h1>
                                                                     <p>
                                         <p>
-	<span style="font-size: 16px;"><strong>Êàê íóæíî èçìåíèòü ñâîå ìûøëåíèå, ÷òîáû âûéòè íà íîâûé óðîâåíü ðàçâèòèÿ áîëüøèì ðûâêîì.</strong></span></p>
+	<span style="font-size: 16px;"><strong>Как нужно изменить свое мышление, чтобы выйти на новый уровень развития большим рывком.</strong></span></p>
 <p>
-	Ïðîìî-âèäåî ñ ìàñòåð-êëàññà Äåíåæíûé èíòåëëåêò-4Q&quot;</p>
+	Промо-видео с мастер-класса Денежный интеллект-4Q&quot;</p>
 <p>
 	&nbsp;</p>
 <p style="text-align: center;">
@@ -434,16 +434,16 @@ function voted(){
 }
 </script>
     <div class='mark' style='white-space: nowrap; width: 208px; overflow: hidden; float: left;'>
-    <div class='service'>Îöåíèòü:</div>
+    <div class='service'>Оценить:</div>
     <div class='stars' id='stars'>
-    <a href='setup11ac.html?id=F4A40&amp;vote=1&amp;close=1' target='_blank' title='Óæàñíî!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup122c.html?id=F4A40&amp;vote=2&amp;close=1' target='_blank' title='Ïëîõî'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupcd73.html?id=F4A40&amp;vote=3&amp;close=1' target='_blank' title='Ñðåäíå'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setup46a5.html?id=F4A40&amp;vote=4&amp;close=1' target='_blank' title='Õîðîøî'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
-    <a href='setupd36f.html?id=F4A40&amp;vote=5&amp;close=1' target='_blank' title='Îòëè÷íî!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup11ac.html?id=F4A40&amp;vote=1&amp;close=1' target='_blank' title='Ужасно!'><div class='' id='star1' onmouseover='light(1)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup122c.html?id=F4A40&amp;vote=2&amp;close=1' target='_blank' title='Плохо'><div class='' id='star2' onmouseover='light(2)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupcd73.html?id=F4A40&amp;vote=3&amp;close=1' target='_blank' title='Средне'><div class='' id='star3' onmouseover='light(3)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setup46a5.html?id=F4A40&amp;vote=4&amp;close=1' target='_blank' title='Хорошо'><div class='' id='star4' onmouseover='light(4)' onmouseout='delight()' onclick='voted()'></div></a>
+    <a href='setupd36f.html?id=F4A40&amp;vote=5&amp;close=1' target='_blank' title='Отлично!'><div class='' id='star5' onmouseover='light(5)' onmouseout='delight()' onclick='voted()'></div></a>
     </div>
     <div class='line' id='line'></div>
-    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Ñïàñèáî!</div>
+    <div id='thanks' style='display: none; float: left; padding-top: 5px;'>Спасибо!</div>
     </div> <div style='padding-top: 10px;'><!-- AddThis Button BEGIN -->
 <div class="addthis_toolbox addthis_default_style addthis_32x32_style">
 <a class="addthis_button_facebook"></a>
@@ -466,12 +466,12 @@ function voted(){
 
 <script type="text/javascript">var addthis_config = {"data_track_clickback":true};</script>
 <script type="text/javascript" src="../s7.addthis.com/js/250/addthis_widget.js#pubid=nlping"></script>
-<!-- AddThis Button END --></div><div class='relateditems'><p>Ëó÷øèå ìàòåðèàëû ðàçäåëà &quot;Âèäåî&quot;</p> <ul><li><a href='F47BA.html' title='Ïî÷åìó ëþäè ìàíèïóëèðóþò, êàê çàùèòèòüñÿ îò ýòîãî è ÷åì ìîòèâàöèÿ îòëè÷àåòñÿ îò ìàíèïóëÿöèè. Ôðàãìåíò ñ ïðåçåíòàöèè êíèãè "ÍËÏ êàê îíî åñòü".'>Ìàíèïóëÿöèÿ</a></li><li><a href='F48E0.html' title='×àñòü ïåðâàÿ: Ïîòîê ðóëèò! Íî âûáîð òû äîëæåí ñäåëàòü ñàì. Âèäåî óðîê â ðàìêàõ òåñò-äðàéâà ïðåäñòîÿùåãî òðåíèíãà.'>Êàê âûéòè çà ïðåäåëû âîçìîæíîãî? (1)</a></li><li><a href='F48E1.html' title='Óðîâíè æèçíè. Êàê âûéòè çà ãðàíèöû òîãî, ÷òî ìû ñ÷èòàåì âîçìîæíûì?'>Êàê âûéòè çà ïðåäåëû âîçìîæíîãî? (2)</a></li><li><a href='F4A2C.html' title='3 ôóíäàìåíòàëüíûõ îñíîâû èíòóöèè'>7 èëè 8?</a></li><li><a href='F4A3F.html' title='Êàê íóæíî èçìåíèòü ñâîå ìûøëåíèå, ÷òîáû âûéòè íà íîâûé óðîâåíü â áèçíåñå.'>Êàê èçáåæàòü êðèçèñà â áèçíåñå</a></li></ul></div> 
-<h3>Êîììåíòàðèè Facebook</h3>
+<!-- AddThis Button END --></div><div class='relateditems'><p>Лучшие материалы раздела &quot;Видео&quot;</p> <ul><li><a href='F47BA.html' title='Почему люди манипулируют, как защититься от этого и чем мотивация отличается от манипуляции. Фрагмент с презентации книги "НЛП как оно есть".'>Манипуляция</a></li><li><a href='F48E0.html' title='Часть первая: Поток рулит! Но выбор ты должен сделать сам. Видео урок в рамках тест-драйва предстоящего тренинга.'>Как выйти за пределы возможного? (1)</a></li><li><a href='F48E1.html' title='Уровни жизни. Как выйти за границы того, что мы считаем возможным?'>Как выйти за пределы возможного? (2)</a></li><li><a href='F4A2C.html' title='3 фундаментальных основы интуции'>7 или 8?</a></li><li><a href='F4A3F.html' title='Как нужно изменить свое мышление, чтобы выйти на новый уровень в бизнесе.'>Как избежать кризиса в бизнесе</a></li></ul></div> 
+<h3>Комментарии Facebook</h3>
 <div id="fb-root"></div>
 <div class="fb-comments" data-href="http://nlping.ru/F4A40" data-num-posts="100" data-width="600"></div>
 
-<h3>Êîììåíòàðèè Âêîíòàêòå</h3>
+<h3>Комментарии Вконтакте</h3>
 <div id="vk_comments"></div>
 <script type="text/javascript">
 VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
@@ -509,12 +509,12 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -538,8 +538,8 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -547,11 +547,11 @@ VK.Widgets.Comments("vk_comments", {limit: 100, width: "600", attach: false});
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -610,7 +610,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -632,7 +632,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/F4A46.html
+++ b/F4A46.html
@@ -4,11 +4,11 @@
     
 <!-- Mirrored from nlping.ru/F4A46 by HTTrack Website Copier/3.x [XR&CO'2014], Fri, 05 Sep 2025 12:54:04 GMT -->
 <head>
-        <title>Êîíòàêòû è ðåêâèçèòû</title>
+        <title>Контакты и реквизиты</title>
         <meta name="robots" content="noindex" />
         <meta name="description" content="" />
         <meta name="keywords" content="" />
-        <meta http-equiv="Content-Type" content="text/html; charset=windows-1251" />
+        <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
         <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="rss/index.html" />
         <link href="favicon.ico" rel="shortcut icon" type="image/x-icon" />
         
@@ -48,11 +48,11 @@
                             <!-- header -->
                 <div id="header">
                     <div id="logo">
-                        <a href="index.html"><img class="png" src="images/logo.png" alt="ÍËÏ" /></a>
+                        <a href="index.html"><img class="png" src="images/logo.png" alt="НЛП" /></a>
                     </div>
                     <div id="header-contacts">
                         <div id="header-mailto">
-                            <a href="javascript:jivo_api.open();">Íàïèøèòå íàì</a>
+                            <a href="javascript:jivo_api.open();">Напишите нам</a>
                         </div>
                         <div id="header-vline">
                         </div>
@@ -65,14 +65,14 @@
                 <div id="search-form">
                     <div id="search-wrapper" class="without-orange">
                         <div id="search-tabs">
-                            <div class="tabs rss"><a href="blog.html">Áëîã</a></div>
-                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Ðàññûëêà</a></div>
-                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Òîï 10</a></div>
+                            <div class="tabs rss"><a href="blog.html">Блог</a></div>
+                            <div class="tabs allanons"><a href="../lp.nlping.ru/subscribe/index.html">Рассылка</a></div>
+                            <div class="tabs top10"><a href="F8098E52-F4631-38207BC3.html">Топ 10</a></div>
                         </div>
                         <div class="h13"></div>
                         <div id="search-form-input">
                             <form action="http://nlping.ru/search" method="get" id="cse-search-box" accept-charset="utf-8">
-                                <input type="text" name="q" value="Ïîèñê ïî ñàéòó..." class="autoclear" />
+                                <input type="text" name="q" value="Поиск по сайту..." class="autoclear" />
                             </form>
                         </div>
                         <table id="search-menu">
@@ -81,28 +81,28 @@
                                                                 <td>
                                     <table id="menu-item-1"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Ñòàòüè è ìàòåðèàëû</a></div></td>
+                                    <td class="item"><div><a href="32347D7E-F4267-B9D62464.html">Статьи и материалы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-2"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Áåñïëàòíûå êóðñû</a></div></td>
+                                    <td class="item"><div><a href="5570BA84-F46E2-6F74003F.html">Бесплатные курсы</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-3"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="F4722">Ìàãàçèí</a></div></td>
+                                    <td class="item"><div><a href="F4722">Магазин</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
                                                                 <td>
                                     <table id="menu-item-4"><tr>
                                     <td class="left"><div class="left"></div></td>
-                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Æèâûå òðåíèíãè</a></div></td>
+                                    <td class="item"><div><a href="E473C076-F4245-A5C815B7.html">Живые тренинги</a></div></td>
                                     <td class="right"><div class="right"></div></td>
                                     </tr></table>
                                 </td>
@@ -120,58 +120,58 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>ÍËÏ è ãèïíîç</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="8A456F4F-F4241-F9B6E5D2.html" ><span>НЛП и гипноз</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Íîâûé Êîä ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D5D634B-F42A7-4825A88E.html" ><span>Новый Код НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Êîó÷èíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="D4B82833-F4612-39FD98B1.html" ><span>Коучинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Ñïèðàëüíàÿ Äèíàìèêà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="716F4063-F45B9-4B9C778A.html" ><span>Спиральная Динамика</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Èíòåãðàëüíàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="98F84D94-F45E7-FB454F52.html" ><span>Интегральная психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Äëÿ ÍËÏåðîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="11E0E292-F4297-CBD0453C.html" ><span>Для НЛПеров</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Ýâîëþöèÿ ðàçóìà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="477C1BB3-F45E9-D845B29A.html" ><span>Эволюция разума</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Ïðàêòè÷åñêàÿ ïñèõîëîãèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7BC8340A-F42C3-8F3965F4.html" ><span>Практическая психология</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Ìóæ÷èíà è æåíùèíà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="401DAD9C-F46D3-E86A6238.html" ><span>Мужчина и женщина</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Áèçíåñ, ìàðêåòèíã è ïðîäàæè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F48A6.html" ><span>Бизнес, маркетинг и продажи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Áàéêè è ïðèò÷è</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="600117C7-F45F0-9F94D6EA.html" ><span>Байки и притчи</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Àóäèî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="audio.html" ><span>Аудио</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Âèäåî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="video.html" ><span>Видео</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Êíèãè è ñàìîó÷èòåëè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="3D9668D0-F436B-A3575E15.html" ><span>Книги и самоучители</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Òåõíèêè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="1524DC52-F4651-2FB51D87.html" ><span>Техники</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Èãðû Íîâîãî Êîäà ÍËÏ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DAEF12B9-F4495-77F033C8" ><span>Игры Нового Кода НЛП</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Ïðåäíàçíà÷åíèå è ñàìîðåàëèçàöèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4C1F.html" ><span>Предназначение и самореализация</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Áëîã ñàéòà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="blog.html" ><span>Блог сайта</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -182,34 +182,34 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Òðîïà ñèëû. Ñåðèàë ïî òðåíèíãó-ïðèêëþ÷åíèþ.</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="tropa_movie.html" target="_blank"><span>Тропа силы. Сериал по тренингу-приключению.</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé ñ ïîìîùüþ Ñïèðàëüíîé äèíàìèêè?  </span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="spiralnaya_dinamika_vvedenie.html" target="_blank"><span>Как мотивировать и вдохновлять людей с помощью Спиральной динамики?  </span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Ñëîè ñîçíàíèÿ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mind-layers.html" target="_blank"><span>Слои сознания</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Êàê äàòü åìó ïîëíóþ ñâîáîäó è áûòü äëÿ íåãî åäèíñòâåííîé?</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="free_and_only.html" target="_blank"><span>Как дать ему полную свободу и быть для него единственной?</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Ìåòîäè÷êà ïî ñîçäàíèþ ðåàëüíîñòè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="creation_of_reality-webinar-reg.html" target="_blank"><span>Методичка по созданию реальности</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Óïðàâëåíèå ýìîöèÿìè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F1DE9315-F42AB-8A44E905" ><span>Управление эмоциями</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Ìåòîä èíòóèöèè</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="DE66AE3D-F46D7-AF324FC3.html" target="_blank"><span>Метод интуиции</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 ñòðàòåãèé, óäâàèâàþùèõ ïðîäàæè òðåíèíãîâ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="training10k.html" target="_blank"><span>8 стратегий, удваивающих продажи тренингов</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Êàê ñîçäàòü òðåíèíã</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4AFC.html" target="_blank"><span>Как создать тренинг</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 èçìåðåíèÿ âàøåãî òðåíèíãà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="bright_tranings.html" target="_blank"><span>4 измерения вашего тренинга</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -220,13 +220,13 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Ëèäåðñòâî</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CF9" ><span>Лидерство</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Ëè÷íàÿ ýôôåêòèâíîñòü</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4CFB" ><span>Личная эффективность</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Ïðåäïðèíèìàòåëþ</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="F4DEB" ><span>Предпринимателю</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -237,19 +237,19 @@
                                 <div class="tr"></div><table>
                             
                                                                 
-                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>ÍËÏ-ïðàêòèê</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="nlp-praktik" ><span>НЛП-практик</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Êóðñ "ÍËÏ îíëàéí"</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="http://lp.nlponline.org/?utm_source=nlping_menu" ><span>Курс "НЛП онлайн"</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Ìîçã 2.0</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="mozg2" ><span>Мозг 2.0</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 óðîâíåé ëèäåðñòâà</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="7ul_2013.html" target="_blank"><span>7 уровней лидерства</span></a></td></tr>
                                     
                                                                         
-                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Òðåíåðû</span></a></td></tr>
+                                    <tr><td><span style="color: white;">-</span> <a href="trainers.html" ><span>Тренеры</span></a></td></tr>
                                     
                                                                     
                                 </table><div class="bri"><div class="bl"></div></div>
@@ -270,8 +270,8 @@
                                                     <table class="left-column">
                                 <tr><td class="top"> </td></tr>
                                 <tr><td class="left-content">
-                                    <span class="header fll">Ðåêîìåíäóåì</span>
-                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Ïðîäóêòû</a></div>
+                                    <span class="header fll">Рекомендуем</span>
+                                    <div class="header-link-products w100">&nbsp&nbsp<a class="pl15" href="../lp.nlping.ru/showcase/index.html">Продукты</a></div>
                                     <br/>
                                     <br/>
                                 </td></tr>
@@ -281,8 +281,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Äîñòèæåíèå öåëè â òðè øàãà" title="Äîñòèæåíèå öåëè â òðè øàãà" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Äîñòèæåíèå öåëè â òðè øàãà</a></strong></td>
+                                                <td width="150" align="center"><img src="img/small_running_man.jpg" class="preview-img" alt="Достижение цели в три шага" title="Достижение цели в три шага" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/effective_goal/index1756.html?utm_source=nlping_left_block">Достижение цели в три шага</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -294,8 +294,8 @@
                                         
                                         <table class="one-product ">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" title="Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé" /></td>
-                                                <td><strong>Áåñïëàòíûé êóðñ<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Êàê ìîòèâèðîâàòü è âäîõíîâëÿòü ëþäåé</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35562.png" class="preview-img" alt="Как мотивировать и вдохновлять людей" title="Как мотивировать и вдохновлять людей" /></td>
+                                                <td><strong>Бесплатный курс<br/><a href="../lp.nlping.ru/spiral_dynamic/index.html">Как мотивировать и вдохновлять людей</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -307,8 +307,8 @@
                                         
                                         <table class="one-product noborder">
                                             <tr>
-                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Óïðàâëåíèå ýìîöèÿìè" title="Óïðàâëåíèå ýìîöèÿìè" /></td>
-                                                <td><strong>Ñàìîó÷èòåëü<br/><a href="../lp.nlping.ru/emotion_control/index.html">Óïðàâëåíèå ýìîöèÿìè</a></strong></td>
+                                                <td width="150" align="center"><img src="../w.nlping.ru/wp-content/uploads/2014/06/35561.png" class="preview-img" alt="Управление эмоциями" title="Управление эмоциями" /></td>
+                                                <td><strong>Самоучитель<br/><a href="../lp.nlping.ru/emotion_control/index.html">Управление эмоциями</a></strong></td>
                                             </tr>
                                         </table>
                                     </td>
@@ -320,7 +320,7 @@
                                             <div class="h20"> </div>
                                             <hr color="white" noshade="1" size="1" style="border: 1px 0px 0px 0px; border-color: white;"/>
 <br/>
-<h1 align="center" style="font-size: 20px;">Áåñïëàòíûå âåáèíàðû</h1>
+<h1 align="center" style="font-size: 20px;">Бесплатные вебинары</h1>
 <br/>
 <iframe src="../lp.nlping.ru/form-mini/index.html" frameborder="0" scrolling="no" width="278" seamless="1" height="409"></iframe>                                        </td></tr></table>
                                         <div class="clr h20"> </div>
@@ -350,26 +350,26 @@
                         
                                                     <div id="poll">
                                 <div class="roundbox poll">
-                                    <div class="opinion"><span>Âûðàçèòü ñâîå ìíåíèå</span></div>
+                                    <div class="opinion"><span>Выразить свое мнение</span></div>
                                     <div class="h50"> </div>
                                     <div class="w240 ml20 pl35">
                                     
-                                                                        <span class="question">Â ÷åì âû õîòåëè áû ïðîêà÷àòüñÿ â ïåðâóþ î÷åðåäü?</span>
+                                                                        <span class="question">В чем вы хотели бы прокачаться в первую очередь?</span>
                                     <div class="h20"> </div>
                                     <form  action="http://nlping.ru/#poll" method="post">
                                         <table width="100%">
                                             <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-1" name="option_id" value="1" /></td>
-                                                <td valign="top" class="label"><label for="voteid-1">Ïåðåãîâîðû</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-1">Переговоры</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-2" name="option_id" value="2" /></td>
-                                                <td valign="top" class="label"><label for="voteid-2">Ìîòèâàöèÿ</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-2">Мотивация</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-3" name="option_id" value="3" /></td>
-                                                <td valign="top" class="label"><label for="voteid-3">Ëèäåðñòâî</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-3">Лидерство</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"><input type="radio" id="voteid-4" name="option_id" value="4" /></td>
-                                                <td valign="top" class="label"><label for="voteid-4">Ýôôåêòèâíîñòü</label><br/><br/></td>
+                                                <td valign="top" class="label"><label for="voteid-4">Эффективность</label><br/><br/></td>
                                             </tr>                                            <tr>
                                                 <td valign="top" class="input"></td>
                                                 <td valign="top" class="label"><input type="submit" value="" class="poll-button" /></td>
@@ -387,7 +387,7 @@
                         <td class="w20"> </td>
                         <td id="content">
                                                                            <div id="pathway">
-                            <span><a href='index.html'>Ãëàâíàÿ</a>  / <a href='F486C.html'>Ìàãàçèí</a> </span> / Êîíòàêòû è ðåêâèçèòû                           </div>
+                            <span><a href='index.html'>Главная</a>  / <a href='F486C.html'>Магазин</a> </span> / Контакты и реквизиты                           </div>
                                                 
                            <div class="content">
                 <div class="clr h15"></div>
@@ -399,31 +399,31 @@
                                 <div class="clr"></div>
                                 <div class="text-content">
                                                                 <div class="print-version"><a href="printffc6.html?id=F4A46"><img src="images/printer.jpg"></a></div>
-                                    <h1>Êîíòàêòû è ðåêâèçèòû</h1>
+                                    <h1>Контакты и реквизиты</h1>
                                                                     <p>
-                                        <h2>Êîíòàêòû</h2>
+                                        <h2>Контакты</h2>
 
-<p>Òåëåôîí: +7 (495) 772-68-73<br />
+<p>Телефон: +7 (495) 772-68-73<br />
 E-mail: info@nlping.ru<br />
-<span style="font-size: 14px; background-color: rgb(255, 255, 255);">Àäðåñ: Ìîñêâà, Ëåíèíãðàäñêèé&nbsp;ïðîñïåêò, 80 êîðï. Ã, îôèñ 910</span></p>
+<span style="font-size: 14px; background-color: rgb(255, 255, 255);">Адрес: Москва, Ленинградский&nbsp;проспект, 80 корп. Г, офис 910</span></p>
 
-<h2>Þðèäè÷åñêàÿ èíôîðìàöèÿ</h2>
+<h2>Юридическая информация</h2>
 
-<p>ÈÏ Áóëûãèí Åãîð Ñåðãååâè÷<br />
-ÎÃÐÍ: 311774611100951<br />
-ÈÍÍ: 772802505050</p>
+<p>ИП Булыгин Егор Сергеевич<br />
+ОГРН: 311774611100951<br />
+ИНН: 772802505050</p>
 
-<h2>Áàíêîâñêèå ðåêâèçèòû</h2>
+<h2>Банковские реквизиты</h2>
 
-<p>Áàíê ïîëó÷àòåëÿ:<br />
-ÂÒÁ 24 (ÇÀÎ), ã. Ìîñêâà<br />
-ÁÈÊ: 044525716<br />
-Ê/ñ: 30101810100000000716<br />
+<p>Банк получателя:<br />
+ВТБ 24 (ЗАО), г. Москва<br />
+БИК: 044525716<br />
+К/с: 30101810100000000716<br />
 <br />
-Ïîëó÷àòåëü:<br />
-ÈÏ Áóëûãèí Åãîð Ñåðãååâè÷<br />
-ð/ñ: 40802810100000036560<br />
-<span style="font-size: 14px; background-color: rgb(255, 255, 255);">ÈÍÍ: 772802505050</span></p>
+Получатель:<br />
+ИП Булыгин Егор Сергеевич<br />
+р/с: 40802810100000036560<br />
+<span style="font-size: 14px; background-color: rgb(255, 255, 255);">ИНН: 772802505050</span></p>
                                     </p>
                                 </div>
                                 <div class="clr"></div>
@@ -439,12 +439,12 @@ E-mail: info@nlping.ru<br />
                            
                             <div class="clr h20"></div>
                                                    <div class="bottom-block">
-                                <span class="header">Ðåêîìåíäóåì</span>
+                                <span class="header">Рекомендуем</span>
                                 <div class="clr h20"> </div>
                                 <div class="roundbox">
                                 	<div class="clr"></div>                                	
 	                                    <div class="content text-content">
-	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Æìèòå, ÷òîáû ïîëó÷èòü äîñòóï" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
+	                                    <p style="text-align: center;"><a href="../webinar.egorbulygin.ru/record/index360b.html?ch=nlping_main&amp;utm_source=nlping_main"><img alt="Жмите, чтобы получить доступ" src="img/art/webinars_600.png" style="width: 600px; height: 400px;" /></a></p>
 
 <p></p>
 
@@ -468,8 +468,8 @@ E-mail: info@nlping.ru<br />
                                                     <div id="footer-block">
                                 <div>
                                     <span class="years">© 2005-2015 <a href="index.html">nlping.ru</a> <br/>
-+7 (495) 772-68-73</span>   Ïí-Ïò ñ 10 äî 19<br/>
-Ìîñêâà, Ïðîñïåêò Ìèðà, 68ñ1, îôèñ 212                                </div>
++7 (495) 772-68-73</span>   Пн-Пт с 10 до 19<br/>
+Москва, Проспект Мира, 68с1, офис 212                                </div>
                             </div>                           
                         </td>
                         <td></td>
@@ -477,11 +477,11 @@ E-mail: info@nlping.ru<br />
                         
                                                     <div id="subscribe">
                                 <div class="h10"> </div>
-                                <div id="frendly-sites"><a href="F4A46.html">Êîíòàêòû è ðåêâèçèòû</a></div>
-                                <div id="mail-icon"><a href="subscribe_news.html">Ðàññûëêà ñàéòà</a></div>
+                                <div id="frendly-sites"><a href="F4A46.html">Контакты и реквизиты</a></div>
+                                <div id="mail-icon"><a href="subscribe_news.html">Рассылка сайта</a></div>
                                 <div id="liveinternet">
-                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Ïóáëè÷íàÿ îôåðòà</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Ñîãëàøåíèå î ïåðñîíàëüíûõ äàííûõ</a></div>
-                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Çäåñü íàõîäèòñÿ àòòåñòàò íàøåãî WM èäåíòèôèêàòîðà 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
+                                    <div style="float: left; margin-top: 5px; font-size: 10px;"><a href="../w.nlping.ru/oferta/index.html">Публичная оферта</a><br/><a href="../w.nlping.ru/soglashenie/index.html">Соглашение о персональных данных</a></div>
+                                    <div style="float: right;"><img src="img/logo/visa.png"> &nbsp;&nbsp; <img src="img/logo/mastercard.png"> &nbsp;&nbsp; <img src="img/logo/wm.png"> &nbsp;&nbsp; <a href="https://passport.webmoney.ru/asp/certview.asp?wmid=429309667875" target=_blank><img src="img/logo/wm_attestat.png" title="Здесь находится аттестат нашего WM идентификатора 429309667875"></a> &nbsp;&nbsp; <img src="img/logo/rbk-money.png"> &nbsp;&nbsp; <img src="img/logo/yandex.png"> &nbsp;&nbsp; <img src="img/logo/z-payment.gif"></div>
                                     <script type="text/javascript">
 var gr_goal_params = {
  param_0 : '',
@@ -540,7 +540,7 @@ var s = document.createElement('script'); s.type = 'text/javascript'; s.async = 
 </script>
 
 
-<!-- Êîä ðåòàðãåòèíãà adroll -->
+<!-- Код ретаргетинга adroll -->
 
 <script type="text/javascript">
 adroll_adv_id = "JC2G2SFFFJBJTE57G2VYGY";
@@ -562,7 +562,7 @@ window.onload = function(){
 
 <script language="JavaScript" type="text/javascript" src="../s.nlping.ru/jsapi/click.js"></script>
 
-<!-- äîáàâèòü ìåòêè ê ññûëêàì -->
+<!-- добавить метки к ссылкам -->
 <script>
 $(".lp_link").attr("href", $(".lp_link").attr("href") + window.location.search);
 </script></div>

--- a/memory-bank/diff-limit-plan.md
+++ b/memory-bank/diff-limit-plan.md
@@ -9,6 +9,7 @@
 | 2025-10-03T13:31Z / Этап D2 GUID F48x (партия 2) | Перекодировка HTML | `F4876.html`…`F48A9.html`, `DOROZHNAYA_KARTA.md` | 14 files, 1264 insertions(+), 1262 deletions(-) | ✅ | Партия `F4876`…`F48A9` прошла без превышения лимита; зафиксированы `logs/reencode-20251003T133116Z.json`, `logs/check_utf8-20251003T133135Z.json`, впереди завершающие `F48AB.html`…`F48ED.html`. |
 | 2025-10-02T15:58Z / Этап D2 GUID D–E | Перекодировка HTML | `D02DBF37-F46B9-834FCE15.html`…`EF55077A-F45BC-9F9EDC1A.html` | 15 files, 1475 insertions(+), 1475 deletions(-) | ✅ | Партия `[DE]*.html`, дифф симметричный, укладывается в лимит. Следующая калибровка — для `F*`. |
 | 2025-10-03T19:52Z / Этап D2 GUID F49x | Перекодировка HTML | `F4902.html`, `F49ED.html`, `DOROZHNAYA_KARTA.md`, `memory-bank/diff-limit-plan.md` | 4 files, 370 insertions(+), 366 deletions(-) | ✅ | Мини-партия на 2 файла подтверждает запас по лимиту; журнал и дорожная карта обновлены, далее планируем `F4Ax`. |
+| 2025-10-03T20:04Z / Этап D2 GUID F4Ax (партия 1) | Перекодировка HTML | `F4A11.html`…`F4A46.html`, `DOROZHNAYA_KARTA.md` | 13 files, 1259 insertions(+), 1256 deletions(-) | ✅ | Партия из 12 GUID-файлов прошла в пределах лимита; зафиксированы `logs/reencode-20251003T200347Z.json`, `logs/check_utf8-20251003T200422Z.json`, следующий блок `F4A47.html`…`F4A99.html`. |
 
 ## Текущие ориентиры
 


### PR DESCRIPTION
## Summary
- convert GUID landing pages F4A11.html–F4A46.html to UTF-8 so Cyrillic text renders correctly and meta tags advertise the new charset
- document the completed batch in the migration roadmap and diff-limit journal, noting the next subset to process

## Testing
- python tools/reencode.py --paths F4A11.html F4A12.html F4A18.html F4A29.html F4A2A.html F4A2B.html F4A2C.html F4A2D.html F4A2F.html F4A3F.html F4A40.html F4A46.html
- python tools/check_utf8.py --no-manifest --scope F4A11.html --scope F4A12.html --scope F4A18.html --scope F4A29.html --scope F4A2A.html --scope F4A2B.html --scope F4A2C.html --scope F4A2D.html --scope F4A2F.html --scope F4A3F.html --scope F4A40.html --scope F4A46.html

------
https://chatgpt.com/codex/tasks/task_e_68e02bdd342083279e2824a865843a26